### PR TITLE
Apply some syntax changes accepted by Python 2 as well as Python 3

### DIFF
--- a/check.cgi
+++ b/check.cgi
@@ -230,7 +230,7 @@ def checker_app(environ, start_response):
                     events = params['loggedEvents']
                     feedType = params['feedType']
                     goon = 1
-                except ValidationFailure, vfv:
+                except ValidationFailure as vfv:
                     yield applyTemplate('header.tmpl', {'title':'Feed Validator Results: %s' % escapeURL(url)})
                     yield applyTemplate('manual.tmpl', {'rawdata':escapeURL(url)})
                     output = Formatter([vfv.event], None)
@@ -249,7 +249,7 @@ def checker_app(environ, start_response):
                     rawdata = params['rawdata']
                     feedType = params['feedType']
                     goon = 1
-                except ValidationFailure, vfv:
+                except ValidationFailure as vfv:
                     yield applyTemplate('header.tmpl', {'title':'Feed Validator Results: %s' % escapeURL(url)})
                     yield applyTemplate('index.tmpl', {'value':escapeURL(url)})
                     output = Formatter([vfv.event], None)

--- a/fcgi.py
+++ b/fcgi.py
@@ -470,7 +470,7 @@ class Record(object):
         while length:
             try:
                 data = sock.recv(length)
-            except socket.error, e:
+            except socket.error as e:
                 if e[0] == errno.EAGAIN:
                     select.select([sock], [], [])
                     continue
@@ -527,7 +527,7 @@ class Record(object):
         while length:
             try:
                 sent = sock.send(data)
-            except socket.error, e:
+            except socket.error as e:
                 if e[0] == errno.EPIPE:
                     return # Don't bother raising an exception. Just ignore.
                 elif e[0] == errno.EAGAIN:
@@ -666,7 +666,7 @@ class Connection(object):
                 self.process_input()
             except EOFError:
                 break
-            except (select.error, socket.error), e:
+            except (select.error, socket.error) as e:
                 if e[0] == errno.EBADF: # Socket was closed by Request.
                     break
                 raise
@@ -991,7 +991,7 @@ class Server(object):
                                  socket.SOCK_STREAM)
             try:
                 sock.getpeername()
-            except socket.error, e:
+            except socket.error as e:
                 if e[0] == errno.ENOTSOCK:
                     # Not a socket, assume CGI context.
                     isFCGI = False
@@ -1072,7 +1072,7 @@ class Server(object):
         while self._keepGoing:
             try:
                 r, w, e = select.select([sock], [], [], timeout)
-            except select.error, e:
+            except select.error as e:
                 if e[0] == errno.EINTR:
                     continue
                 raise
@@ -1080,7 +1080,7 @@ class Server(object):
             if r:
                 try:
                     clientSock, addr = sock.accept()
-                except socket.error, e:
+                except socket.error as e:
                     if e[0] in (errno.EINTR, errno.EAGAIN):
                         continue
                     raise
@@ -1150,7 +1150,7 @@ class WSGIServer(Server):
 
         Set multithreaded to False if your application is not MT-safe.
         """
-        if kw.has_key('handler'):
+        if 'handler' in kw:
             del kw['handler'] # Doesn't make sense to let this through
         super(WSGIServer, self).__init__(**kw)
 
@@ -1274,9 +1274,9 @@ class WSGIServer(Server):
 
     def _sanitizeEnv(self, environ):
         """Ensure certain values are present, if required by WSGI."""
-        if not environ.has_key('SCRIPT_NAME'):
+        if 'SCRIPT_NAME' not in environ:
             environ['SCRIPT_NAME'] = ''
-        if not environ.has_key('PATH_INFO'):
+        if 'PATH_INFO' not in environ:
             environ['PATH_INFO'] = ''
 
         # If any of these are missing, it probably signifies a broken
@@ -1285,7 +1285,7 @@ class WSGIServer(Server):
                              ('SERVER_NAME', 'localhost'),
                              ('SERVER_PORT', '80'),
                              ('SERVER_PROTOCOL', 'HTTP/1.0')]:
-            if not environ.has_key(name):
+            if name not in environ:
                 environ['wsgi.errors'].write('%s: missing FastCGI param %s '
                                              'required by WSGI!\n' %
                                              (self.__class__.__name__, name))
@@ -1304,7 +1304,7 @@ if __name__ == '__main__':
         names.sort()
         for name in names:
             yield '<tr><td>%s</td><td>%s</td></tr>\n' % (
-                name, cgi.escape(`environ[name]`))
+                name, cgi.escape(repr(environ[name])))
 
         form = cgi.FieldStorage(fp=environ['wsgi.input'], environ=environ,
                                 keep_blank_values=1)

--- a/feedfinder.py
+++ b/feedfinder.py
@@ -111,7 +111,7 @@ class URLGatekeeper:
 
     def _getrp(self, url):
         protocol, domain = urlparse.urlparse(url)[:2]
-        if self.rpcache.has_key(domain):
+        if domain in self.rpcache:
             return self.rpcache[domain]
         baseurl = '%s://%s' % (protocol, domain)
         robotsurl = urlparse.urljoin(baseurl, 'robots.txt')
@@ -158,7 +158,7 @@ class BaseParser(sgmllib.SGMLParser):
 
     def do_base(self, attrs):
         attrsD = dict(self.normalize_attrs(attrs))
-        if not attrsD.has_key('href'): return
+        if 'href' not in attrsD: return
         self.baseuri = attrsD['href']
 
     def error(self, *a, **kw): pass # we're not picky
@@ -171,17 +171,17 @@ class LinkParser(BaseParser):
                   'application/x-atom+xml')
     def do_link(self, attrs):
         attrsD = dict(self.normalize_attrs(attrs))
-        if not attrsD.has_key('rel'): return
+        if 'rel' not in attrsD: return
         rels = attrsD['rel'].split()
         if 'alternate' not in rels: return
         if attrsD.get('type') not in self.FEED_TYPES: return
-        if not attrsD.has_key('href'): return
+        if 'href' not in attrsD: return
         self.links.append(urlparse.urljoin(self.baseuri, attrsD['href']))
 
 class ALinkParser(BaseParser):
     def start_a(self, attrs):
         attrsD = dict(self.normalize_attrs(attrs))
-        if not attrsD.has_key('href'): return
+        if 'href' not in attrsD: return
         self.links.append(urlparse.urljoin(self.baseuri, attrsD['href']))
 
 def makeFullURI(uri):
@@ -299,7 +299,7 @@ def feeds(uri, all=False, querySyndic8=False):
         # still no luck, search Syndic8 for feeds (requires xmlrpclib)
         _debuglog('still no luck, searching Syndic8')
         feeds.extend(getFeedsFromSyndic8(uri))
-    if hasattr(__builtins__, 'set') or __builtins__.has_key('set'):
+    if hasattr(__builtins__, 'set') or 'set' in __builtins__:
         feeds = list(set(feeds))
     return feeds
 

--- a/src/demo.py
+++ b/src/demo.py
@@ -29,7 +29,7 @@ if __name__ == '__main__':
       events = feedvalidator.validateStream(urllib.urlopen(link), firstOccurrenceOnly=1,base=link.replace(basedir,"http://www.feedvalidator.org/"))['loggedEvents']
     else:
       events = feedvalidator.validateURL(link, firstOccurrenceOnly=1)['loggedEvents']
-  except feedvalidator.logging.ValidationFailure, vf:
+  except feedvalidator.logging.ValidationFailure as vf:
     events = [vf.event]
 
   # (optional) arg 2 is compatibility level

--- a/src/feedvalidator/__init__.py
+++ b/src/feedvalidator/__init__.py
@@ -7,18 +7,18 @@ if hasattr(socket, 'setdefaulttimeout'):
   socket.setdefaulttimeout(10)
   Timeout = socket.timeout
 else:
-  import timeoutsocket
+  from . import timeoutsocket
   timeoutsocket.setDefaultSocketTimeout(10)
   Timeout = timeoutsocket.Timeout
 
 import urllib2
-import logging
-from logging import *
+from . import logging
+from .logging import *
 from xml.sax import SAXException
 from xml.sax.xmlreader import InputSource
 import re
-import xmlEncoding
-import mediaTypes
+from . import xmlEncoding
+from . import mediaTypes
 from httplib import BadStatusLine
 
 MAXDATALENGTH = 2000000
@@ -40,7 +40,7 @@ def sniffPossibleFeed(rawdata):
 def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfURIs=None, mediaType=None):
   """validate RSS from string, returns validator object"""
   from xml.sax import make_parser, handler
-  from base import SAXDispatcher
+  from .base import SAXDispatcher
   from exceptions import UnicodeError
   from cStringIO import StringIO
 
@@ -69,7 +69,7 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
   validator.rssCharData = [s.find('&#x')>=0 for s in aString.split('\n')]
 
   xmlver = re.match("^<\?\s*xml\s+version\s*=\s*['\"]([-a-zA-Z0-9_.:]*)['\"]",aString)
-  if xmlver and xmlver.group(1)<>'1.0':
+  if xmlver and xmlver.group(1)!='1.0':
     validator.log(logging.BadXmlVersion({"version":xmlver.group(1)}))
 
   try:
@@ -194,7 +194,7 @@ def validateURL(url, firstOccurrenceOnly=1, wantRawData=0):
         raise ValidationFailure(logging.ValidatorLimit({'limit': 'feed length > ' + str(MAXDATALENGTH) + ' bytes'}))
 
       # check for temporary redirects
-      if usock.geturl()<>request.get_full_url():
+      if usock.geturl()!=request.get_full_url():
         from urlparse import urlsplit
         (scheme, netloc, path, query, fragment) = urlsplit(url)
         if scheme == 'http':
@@ -204,13 +204,13 @@ def validateURL(url, firstOccurrenceOnly=1, wantRawData=0):
           conn=HTTPConnection(netloc)
           conn.request("GET", requestUri)
           resp=conn.getresponse()
-          if resp.status<>301:
+          if resp.status!=301:
             loggedEvents.append(TempRedirect({}))
 
-    except BadStatusLine, status:
+    except BadStatusLine as status:
       raise ValidationFailure(logging.HttpError({'status': status.__class__}))
 
-    except urllib2.HTTPError, status:
+    except urllib2.HTTPError as status:
       rawdata = status.read()
       if len(rawdata) < 512 or 'content-encoding' in status.headers:
         loggedEvents.append(logging.HttpError({'status': status}))
@@ -224,11 +224,11 @@ def validateURL(url, firstOccurrenceOnly=1, wantRawData=0):
           usock = status
         else:
           raise ValidationFailure(logging.HttpError({'status': status}))
-    except urllib2.URLError, x:
+    except urllib2.URLError as x:
       raise ValidationFailure(logging.HttpError({'status': x.reason}))
-    except Timeout, x:
+    except Timeout as x:
       raise ValidationFailure(logging.IOError({"message": 'Server timed out', "exception":x}))
-    except Exception, x:
+    except Exception as x:
       raise ValidationFailure(logging.IOError({"message": x.__class__.__name__,
         "exception":x}))
 

--- a/src/feedvalidator/__init__.py
+++ b/src/feedvalidator/__init__.py
@@ -69,7 +69,7 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
   validator.rssCharData = [s.find('&#x')>=0 for s in aString.split('\n')]
 
   xmlver = re.match("^<\?\s*xml\s+version\s*=\s*['\"]([-a-zA-Z0-9_.:]*)['\"]",aString)
-  if xmlver and xmlver.group(1)!='1.0':
+  if xmlver and xmlver.group(1) != '1.0':
     validator.log(logging.BadXmlVersion({"version":xmlver.group(1)}))
 
   try:
@@ -194,7 +194,7 @@ def validateURL(url, firstOccurrenceOnly=1, wantRawData=0):
         raise ValidationFailure(logging.ValidatorLimit({'limit': 'feed length > ' + str(MAXDATALENGTH) + ' bytes'}))
 
       # check for temporary redirects
-      if usock.geturl()!=request.get_full_url():
+      if usock.geturl() != request.get_full_url():
         from urlparse import urlsplit
         (scheme, netloc, path, query, fragment) = urlsplit(url)
         if scheme == 'http':
@@ -204,7 +204,7 @@ def validateURL(url, firstOccurrenceOnly=1, wantRawData=0):
           conn=HTTPConnection(netloc)
           conn.request("GET", requestUri)
           resp=conn.getresponse()
-          if resp.status!=301:
+          if resp.status != 301:
             loggedEvents.append(TempRedirect({}))
 
     except BadStatusLine as status:

--- a/src/feedvalidator/author.py
+++ b/src/feedvalidator/author.py
@@ -2,8 +2,8 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
+from .base import validatorBase
+from .validators import *
 
 #
 # author element.
@@ -41,7 +41,7 @@ class author(validatorBase):
     return text()
 
   def do_xhtml_div(self):
-    from content import diveater
+    from .content import diveater
     return diveater()
 
   # RSS/Atom support

--- a/src/feedvalidator/base.py
+++ b/src/feedvalidator/base.py
@@ -547,7 +547,7 @@ class validatorBase(ContentHandler):
       column=column+1
       if ord(c) in (10,13):
         column=0
-	line=line+1
+        line=line+1
 
     self.value = self.value + string
 

--- a/src/feedvalidator/base.py
+++ b/src/feedvalidator/base.py
@@ -427,7 +427,7 @@ class validatorBase(ContentHandler):
 
     from .validators import eater
     feedtype=self.getFeedType()
-    if (not qname) and feedtype and (feedtype!=TYPE_RSS2):
+    if (not qname) and feedtype and (feedtype != TYPE_RSS2):
        from .logging import UndeterminableVocabulary
        self.log(UndeterminableVocabulary({"parent":self.name, "element":name, "namespace":'""'}))
        qname="null"

--- a/src/feedvalidator/base.py
+++ b/src/feedvalidator/base.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 from xml.sax.handler import ContentHandler
 from xml.sax.xmlreader import Locator
-from logging import NonCanonicalURI, NotUTF8
+from .logging import NonCanonicalURI, NotUTF8
 import re
 
 # references:
@@ -113,7 +113,7 @@ class SAXDispatcher(ContentHandler):
   firstOccurrenceOnly = 0
 
   def __init__(self, base, selfURIs, encoding):
-    from root import root
+    from .root import root
     ContentHandler.__init__(self)
     self.lastKnownLine = 1
     self.lastKnownColumn = 0
@@ -146,43 +146,43 @@ class SAXDispatcher(ContentHandler):
       self.error(SAXException('Invalid Namespace: %s' % uri))
     if prefix in namespaces.values():
       if not namespaces.get(uri,'') == prefix and prefix:
-        from logging import ReservedPrefix, MediaRssNamespace
+        from .logging import ReservedPrefix, MediaRssNamespace
         preferredURI = [key for key, value in namespaces.items() if value == prefix][0]
         if uri == 'http://search.yahoo.com/mrss':
           self.log(MediaRssNamespace({'prefix':prefix, 'ns':preferredURI}))
         else:
           self.log(ReservedPrefix({'prefix':prefix, 'ns':preferredURI}))
       elif prefix=='wiki' and uri.find('usemod')>=0:
-        from logging import ObsoleteWikiNamespace
+        from .logging import ObsoleteWikiNamespace
         self.log(ObsoleteWikiNamespace({'preferred':namespaces[uri], 'ns':uri}))
       elif prefix in ['atom','xhtml']:
-        from logging import TYPE_ATOM, AvoidNamespacePrefix
+        from .logging import TYPE_ATOM, AvoidNamespacePrefix
         if self.getFeedType() == TYPE_ATOM:
           self.log(AvoidNamespacePrefix({'prefix':prefix}))
-    elif namespaces.has_key(uri):
+    elif uri in namespaces:
       if not namespaces[uri] == prefix and prefix:
-        from logging import NonstdPrefix
+        from .logging import NonstdPrefix
         self.log(NonstdPrefix({'preferred':namespaces[uri], 'ns':uri}))
         if namespaces[uri] in ['atom', 'xhtml']:
-          from logging import TYPE_UNKNOWN, TYPE_ATOM, AvoidNamespacePrefix
+          from .logging import TYPE_UNKNOWN, TYPE_ATOM, AvoidNamespacePrefix
           if self.getFeedType() in [TYPE_ATOM,TYPE_UNKNOWN]:
             self.log(AvoidNamespacePrefix({'prefix':prefix}))
     elif uri == 'http://search.yahoo.com/mrss':
-      from logging import MediaRssNamespace
+      from .logging import MediaRssNamespace
       uri = 'http://search.yahoo.com/mrss/'
       self.log(MediaRssNamespace({'prefix':prefix, 'ns':uri}))
     else:
-      from validators import rfc3987
+      from .validators import rfc3987
       rule=rfc3987()
       rule.setElement('xmlns:'+str(prefix), {}, self.handler_stack[-1][0])
       rule.value=uri
       if not uri or rule.validate():
         if uri in unsupported_namespaces:
-          from logging import UnsupportedNamespace
+          from .logging import UnsupportedNamespace
           (name, specification) = unsupported_namespaces[uri]
           self.log(UnsupportedNamespace({'namespace': uri, 'name': name, 'specification': specification}))
         else:
-          from logging import UnknownNamespace
+          from .logging import UnknownNamespace
           self.log(UnknownNamespace({'namespace':uri}))
 
   def namespaceFor(self, prefix):
@@ -205,10 +205,10 @@ class SAXDispatcher(ContentHandler):
         if u[0] and near_miss(u[0]) not in nearly_namespaces:
           feedtype=self.getFeedType()
           if (not qname) and feedtype and (feedtype==TYPE_RSS2):
-            from logging import UseOfExtensionAttr
+            from .logging import UseOfExtensionAttr
             self.log(UseOfExtensionAttr({"attribute":u, "element":name}))
           continue
-        from logging import UnexpectedAttribute
+        from .logging import UnexpectedAttribute
         if not u[0]: u=u[1]
         self.log(UnexpectedAttribute({"parent":name, "attribute":u, "element":name}))
 
@@ -219,7 +219,7 @@ class SAXDispatcher(ContentHandler):
 
     try:
       def log(exception):
-        from logging import SAXError
+        from .logging import SAXError
         self.log(SAXError({'exception':str(exception)}))
       if self.xmlvalidator:
         self.xmlvalidator(log)
@@ -229,15 +229,15 @@ class SAXDispatcher(ContentHandler):
 
     if (publicId=='-//Netscape Communications//DTD RSS 0.91//EN' and
         systemId=='http://my.netscape.com/publish/formats/rss-0.91.dtd'):
-      from logging import ValidDoctype, DeprecatedDTD
+      from .logging import ValidDoctype, DeprecatedDTD
       self.log(ValidDoctype({}))
       self.log(DeprecatedDTD({}))
     elif (publicId=='-//Netscape Communications//DTD RSS 0.91//EN' and
         systemId=='http://www.rssboard.org/rss-0.91.dtd'):
-      from logging import ValidDoctype
+      from .logging import ValidDoctype
       self.log(ValidDoctype({}))
     else:
-      from logging import ContainsSystemEntity
+      from .logging import ContainsSystemEntity
       self.lastKnownLine = self.locator.getLineNumber()
       self.lastKnownColumn = self.locator.getColumnNumber()
       self.log(ContainsSystemEntity({}))
@@ -245,11 +245,11 @@ class SAXDispatcher(ContentHandler):
     return StringIO()
 
   def skippedEntity(self, name):
-    from logging import ValidDoctype
+    from .logging import ValidDoctype
     if [e for e in self.loggedEvents if e.__class__ == ValidDoctype]:
       from htmlentitydefs import name2codepoint
       if name in name2codepoint: return
-    from logging import UndefinedNamedEntity
+    from .logging import UndefinedNamedEntity
     self.log(UndefinedNamedEntity({'value':name}))
 
   def characters(self, string):
@@ -292,7 +292,7 @@ class SAXDispatcher(ContentHandler):
         else:
           return dup
 
-    if event.params.has_key('element') and event.params['element']:
+    if 'element' in event.params and event.params['element']:
       if not isinstance(event.params['element'],tuple):
         event.params['element']=':'.join(event.params['element'].split('_', 1))
       elif event.params['element'][0]==u'http://www.w3.org/XML/1998/namespace':
@@ -317,7 +317,7 @@ class SAXDispatcher(ContentHandler):
     self.loggedEvents.append(event)
 
   def error(self, exception):
-    from logging import SAXError
+    from .logging import SAXError
     self.log(SAXError({'exception':str(exception)}))
     raise exception
   fatalError=error
@@ -346,7 +346,7 @@ class SAXDispatcher(ContentHandler):
 # Hooks are also provided for subclasses to do "prevalidation" and
 # "validation".
 #
-from logging import TYPE_RSS2
+from .logging import TYPE_RSS2
 
 class validatorBase(ContentHandler):
 
@@ -369,9 +369,9 @@ class validatorBase(ContentHandler):
     self.col  = self.dispatcher.locator.getColumnNumber()
     self.xmlLang = parent.xmlLang
 
-    if attrs and attrs.has_key((u'http://www.w3.org/XML/1998/namespace', u'base')):
+    if attrs and (u'http://www.w3.org/XML/1998/namespace', u'base') in attrs:
       self.xmlBase=attrs.getValue((u'http://www.w3.org/XML/1998/namespace', u'base'))
-      from validators import rfc3987
+      from .validators import rfc3987
       self.validate_attribute((u'http://www.w3.org/XML/1998/namespace',u'base'),
           rfc3987)
       from urlparse import urljoin
@@ -386,7 +386,7 @@ class validatorBase(ContentHandler):
     return namespaces.get(name[0], name[0]) + ":" + name[1]
 
   def namespaceFor(self, prefix):
-    if self.namespace.has_key(prefix):
+    if prefix in self.namespace:
       return self.namespace[prefix]
     elif self.parent:
       return self.parent.namespaceFor(prefix)
@@ -401,40 +401,40 @@ class validatorBase(ContentHandler):
     rule.validate()
 
   def validate_required_attribute(self, name, rule):
-    if self.attrs and self.attrs.has_key(name):
+    if self.attrs and name in self.attrs:
       self.validate_attribute(name, rule)
     else:
-      from logging import MissingAttribute
+      from .logging import MissingAttribute
       self.log(MissingAttribute({"attr": self.simplename(name)}))
 
   def validate_optional_attribute(self, name, rule):
-    if self.attrs and self.attrs.has_key(name):
+    if self.attrs and name in self.attrs:
       self.validate_attribute(name, rule)
 
   def getExpectedAttrNames(self):
     None
 
   def unknown_starttag(self, name, qname, attrs):
-    from validators import any
+    from .validators import any
     return any(self, name, qname, attrs)
 
   def startElementNS(self, name, qname, attrs):
-    if attrs.has_key((u'http://www.w3.org/XML/1998/namespace', u'lang')):
+    if (u'http://www.w3.org/XML/1998/namespace', u'lang') in attrs:
       self.xmlLang=attrs.getValue((u'http://www.w3.org/XML/1998/namespace', u'lang'))
       if self.xmlLang:
-        from validators import iso639_validate
+        from .validators import iso639_validate
         iso639_validate(self.log, self.xmlLang, "xml:lang", name)
 
-    from validators import eater
+    from .validators import eater
     feedtype=self.getFeedType()
     if (not qname) and feedtype and (feedtype!=TYPE_RSS2):
-       from logging import UndeterminableVocabulary
+       from .logging import UndeterminableVocabulary
        self.log(UndeterminableVocabulary({"parent":self.name, "element":name, "namespace":'""'}))
        qname="null"
     if qname in self.dispatcher.defaultNamespaces: qname=None
 
     nm_qname = near_miss(qname)
-    if nearly_namespaces.has_key(nm_qname):
+    if nm_qname in nearly_namespaces:
       prefix = nearly_namespaces[nm_qname]
       qname, name = None, prefix + "_" + name
       if prefix == 'itunes' and not self.itunes and not self.parent.itunes:
@@ -443,17 +443,17 @@ class validatorBase(ContentHandler):
     # ensure all attribute namespaces are properly defined
     for (namespace,attr) in attrs.keys():
       if ':' in attr and not namespace:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":self.name, "element":attr}))
 
     if qname=='http://purl.org/atom/ns#':
-      from logging import ObsoleteNamespace
+      from .logging import ObsoleteNamespace
       self.log(ObsoleteNamespace({"element":"feed"}))
 
     for key, string in attrs.items():
       for c in string:
         if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
-          from validators import BadCharacters
+          from .validators import BadCharacters
           self.log(BadCharacters({"parent":name, "element":key[-1]}))
 
     if qname:
@@ -470,20 +470,20 @@ class validatorBase(ContentHandler):
           handler = getattr(self, "do_" + name.replace("-","_"))()
       except AttributeError:
         if name.find(':') != -1:
-          from logging import MissingNamespace
+          from .logging import MissingNamespace
           self.log(MissingNamespace({"parent":self.name, "element":name}))
           handler = eater()
         elif name.startswith('xhtml_'):
-          from logging import MisplacedXHTMLContent
+          from .logging import MisplacedXHTMLContent
           self.log(MisplacedXHTMLContent({"parent": ':'.join(self.name.split("_",1)), "element":name}))
           handler = eater()
         else:
           try:
-            from extension import Questionable
+            from .extension import Questionable
 
             # requalify the name with the default namespace
             qname = name
-            from logging import TYPE_APP_CATEGORIES, TYPE_APP_SERVICE
+            from .logging import TYPE_APP_CATEGORIES, TYPE_APP_SERVICE
             if self.getFeedType() in [TYPE_APP_CATEGORIES, TYPE_APP_SERVICE]:
               if qname.startswith('app_'): qname=qname[4:]
 
@@ -493,11 +493,11 @@ class validatorBase(ContentHandler):
 
             # is this element questionable?
             handler = getattr(Questionable(), "do_" + qname.replace("-","_"))()
-            from logging import QuestionableUsage
+            from .logging import QuestionableUsage
             self.log(QuestionableUsage({"parent": ':'.join(self.name.split("_",1)), "element":qname}))
 
           except AttributeError:
-            from logging import UndefinedElement
+            from .logging import UndefinedElement
             self.log(UndefinedElement({"parent": ':'.join(self.name.split("_",1)), "element":name}))
             handler = eater()
 
@@ -515,11 +515,11 @@ class validatorBase(ContentHandler):
     self.normalizeWhitespace()
     self.validate()
     if self.isValid and self.name:
-      from validators import ValidElement
+      from .validators import ValidElement
       self.log(ValidElement({"parent":self.parent.name, "element":name}))
 
   def textOK(self):
-    from validators import UnexpectedText
+    from .validators import UnexpectedText
     self.log(UnexpectedText({"element":self.name,"parent":self.parent.name}))
 
   def characters(self, string):
@@ -534,7 +534,7 @@ class validatorBase(ContentHandler):
         if 0xC2 <= ord(pc) <= 0xC3:
           try:
             string.encode('iso-8859-1').decode('utf-8')
-            from validators import BadCharacters
+            from .validators import BadCharacters
             self.log(BadCharacters({"parent":self.parent.name, "element":self.name}), offset=(line,max(1,column-1)))
           except:
             pass
@@ -542,7 +542,7 @@ class validatorBase(ContentHandler):
 
       # win1252
       if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
-        from validators import BadCharacters
+        from .validators import BadCharacters
         self.log(BadCharacters({"parent":self.parent.name, "element":self.name}), offset=(line,column))
       column=column+1
       if ord(c) in (10,13):
@@ -552,7 +552,7 @@ class validatorBase(ContentHandler):
     self.value = self.value + string
 
   def log(self, event, offset=(0,0)):
-    if not event.params.has_key('element'):
+    if 'element' not in event.params:
       event.params['element'] = self.name
     self.dispatcher.log(event, offset)
     self.isValid = 0
@@ -567,7 +567,7 @@ class validatorBase(ContentHandler):
     self.dispatcher.push(handler, name, value, self)
 
   def leaf(self):
-    from validators import text
+    from .validators import text
     return text()
 
   def prevalidate(self):

--- a/src/feedvalidator/categories.py
+++ b/src/feedvalidator/categories.py
@@ -1,7 +1,7 @@
-from base import validatorBase
-from category import category
-from validators import yesno
-from logging import ConflictingCatAttr, ConflictingCatChildren
+from .base import validatorBase
+from .category import category
+from .validators import yesno
+from .logging import ConflictingCatAttr, ConflictingCatChildren
 
 class categories(validatorBase):
   def getExpectedAttrNames(self):
@@ -10,14 +10,14 @@ class categories(validatorBase):
   def prevalidate(self):
     self.validate_optional_attribute((None,'fixed'), yesno)
 
-    if self.attrs.has_key((None,'href')):
-      if self.attrs.has_key((None,'fixed')):
+    if (None,'href') in self.attrs:
+      if (None,'fixed') in self.attrs:
         self.log(ConflictingCatAttr({'attr':'fixed'}))
-      if self.attrs.has_key((None,'scheme')):
+      if (None,'scheme') in self.attrs:
         self.log(ConflictingCatAttr({'attr':'scheme'}))
 
   def validate(self):
-    if self.attrs.has_key((None,'href')) and self.children:
+    if (None,'href') in self.attrs and self.children:
       self.log(ConflictingCatChildren({}))
 
   def do_atom_category(self):

--- a/src/feedvalidator/category.py
+++ b/src/feedvalidator/category.py
@@ -2,8 +2,8 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
+from .base import validatorBase
+from .validators import *
 
 #
 # author element.

--- a/src/feedvalidator/cf.py
+++ b/src/feedvalidator/cf.py
@@ -1,7 +1,7 @@
 # http://msdn.microsoft.com/XML/rss/sle/default.aspx
 
-from base import validatorBase
-from validators import eater, text
+from .base import validatorBase
+from .validators import eater, text
 
 class sort(validatorBase):
   def getExpectedAttrNames(self):

--- a/src/feedvalidator/channel.py
+++ b/src/feedvalidator/channel.py
@@ -2,11 +2,11 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from logging import *
-from validators import *
-from itunes import itunes_channel
-from extension import *
+from .base import validatorBase
+from .logging import *
+from .validators import *
+from .itunes import itunes_channel
+from .extension import *
 
 #
 # channel element.
@@ -41,7 +41,7 @@ class channel(validatorBase, rfc2396, extension_channel, itunes_channel):
       self.log(DuplicateElement({"parent":self.name, "element":"skipHours"}))
     if self.children.count("skipDays") > 1:
       self.log(DuplicateElement({"parent":self.name, "element":"skipDays"}))
-    if self.attrs.has_key((rdfNS,"about")):
+    if (rdfNS,"about") in self.attrs:
       self.value = self.attrs.getValue((rdfNS, "about"))
       rfc2396.validate(self, extraParams={"attr": "rdf:about"})
       if not "items" in self.children:
@@ -66,17 +66,17 @@ class channel(validatorBase, rfc2396, extension_channel, itunes_channel):
 
   def do_image(self):
     self.metadata()
-    from image import image
+    from .image import image
     return image(), noduplicates()
 
   def do_textInput(self):
     self.metadata()
-    from textInput import textInput
+    from .textInput import textInput
     return textInput(), noduplicates()
 
   def do_textinput(self):
     self.metadata()
-    if not self.attrs.has_key((rdfNS,"about")):
+    if (rdfNS,"about") not in self.attrs:
       # optimize for RSS 2.0.  If it is not valid RDF, assume that it is
       # a simple misspelling (in other words, the error message will be
       # less than helpful on RSS 1.0 feeds.
@@ -99,19 +99,19 @@ class channel(validatorBase, rfc2396, extension_channel, itunes_channel):
     return blink(), noduplicates()
 
   def do_atom_author(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_atom_category(self):
-    from category import category
+    from .category import category
     return category()
 
   def do_atom_contributor(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_atom_generator(self):
-    from generator import generator
+    from .generator import generator
     return generator(), nonblank(), noduplicates()
 
   def do_atom_id(self):
@@ -122,7 +122,7 @@ class channel(validatorBase, rfc2396, extension_channel, itunes_channel):
 
   def do_atom_link(self):
     self.metadata()
-    from link import link
+    from .link import link
     self.links.append(link())
     return self.links[-1]
 
@@ -130,15 +130,15 @@ class channel(validatorBase, rfc2396, extension_channel, itunes_channel):
     return nonblank(), rfc2396(), noduplicates()
 
   def do_atom_title(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_subtitle(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_rights(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_updated(self):
@@ -188,7 +188,7 @@ class rss20Channel(channel):
   def do_item(self):
     locator=self.dispatcher.locator
     self.itemlocs.append((locator.getLineNumber(), locator.getColumnNumber()))
-    from item import rss20Item
+    from .item import rss20Item
     return rss20Item()
 
   def do_category(self):
@@ -253,12 +253,12 @@ class rss20Channel(channel):
 
   def do_skipHours(self):
     self.metadata()
-    from skipHours import skipHours
+    from .skipHours import skipHours
     return skipHours()
 
   def do_skipDays(self):
     self.metadata()
-    from skipDays import skipDays
+    from .skipDays import skipDays
     return skipDays()
 
 class rss10Channel(channel):
@@ -267,15 +267,15 @@ class rss10Channel(channel):
       (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about')]
 
   def prevalidate(self):
-    if self.attrs.has_key((rdfNS,"about")):
+    if (rdfNS,"about") in self.attrs:
       if not "abouts" in self.dispatcher.__dict__:
         self.dispatcher.__dict__["abouts"] = []
       self.dispatcher.__dict__["abouts"].append(self.attrs[(rdfNS,"about")])
 
   def do_items(self): # this actually should be from the rss1.0 ns
-    if not self.attrs.has_key((rdfNS,"about")):
+    if (rdfNS,"about") not in self.attrs:
       self.log(MissingAttribute({"parent":self.name, "element":self.name, "attr":"rdf:about"}))
-    from item import items
+    from .item import items
     return items(), noduplicates()
 
   def do_rdfs_label(self):

--- a/src/feedvalidator/compatibility.py
+++ b/src/feedvalidator/compatibility.py
@@ -2,7 +2,7 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from logging import *
+from .logging import *
 
 def _must(event):
   return isinstance(event, Error)

--- a/src/feedvalidator/content.py
+++ b/src/feedvalidator/content.py
@@ -103,7 +103,7 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
     validatorBase.characters(self,string)
 
   def startElementNS(self, name, qname, attrs):
-    if (self.type!='xhtml') and not (
+    if (self.type != 'xhtml') and not (
         self.type.endswith('+xml') or self.type.endswith('/xml')):
       self.log(UndefinedElement({"parent":self.name, "element":name}))
 
@@ -117,7 +117,7 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
         self.log(NotHtml({"parent":self.parent.name, "element":self.name, "message":"unexpected namespace", "value": qname}))
 
     if self.type=="application/xhtml+xml":
-      if name!='html':
+      if name != 'html':
         self.log(HtmlFragment({"parent":self.parent.name, "element":self.name,"value":self.value, "type":self.type}))
       elif qname not in ["http://www.w3.org/1999/xhtml"]:
         self.log(NotHtml({"parent":self.parent.name, "element":self.name, "message":"unexpected namespace", "value":qname}))

--- a/src/feedvalidator/content.py
+++ b/src/feedvalidator/content.py
@@ -2,9 +2,9 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase, namespaces
-from validators import *
-from logging import *
+from .base import validatorBase, namespaces
+from .validators import *
+from .logging import *
 
 def _isXhtmlDiv(ns, elem):
   return ns == 'http://www.w3.org/1999/xhtml' and elem == 'div'
@@ -13,7 +13,7 @@ def _isXhtmlDiv(ns, elem):
 # item element.
 #
 class textConstruct(validatorBase,rfc2396,nonhtml):
-  from validators import mime_re
+  from .validators import mime_re
   import re
 
   def getExpectedAttrNames(self):
@@ -28,30 +28,30 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
 
   def prevalidate(self):
     nonhtml.start(self)
-    if self.attrs.has_key((None,"src")):
+    if (None,"src") in self.attrs:
       self.type=''
     else:
       self.type='text'
       if self.getFeedType() == TYPE_RSS2 and self.name != 'atom_summary':
         self.log(DuplicateDescriptionSemantics({"element":self.name}))
 
-    if self.attrs.has_key((None,"type")):
+    if (None,"type") in self.attrs:
       self.type=self.attrs.getValue((None,"type"))
       if not self.type:
         self.log(AttrNotBlank({"parent":self.parent.name, "element":self.name, "attr":"type"}))
 
     self.maptype()
 
-    if self.attrs.has_key((None,"src")):
+    if (None,"src") in self.attrs:
       self.children.append(True) # force warnings about "mixed" content
       self.value=self.attrs.getValue((None,"src"))
       rfc2396.validate(self, errorClass=InvalidURIAttribute, extraParams={"attr": "src"})
       self.value=""
 
-      if not self.attrs.has_key((None,"type")):
+      if (None,"type") not in self.attrs:
         self.log(MissingTypeAttr({"parent":self.parent.name, "element":self.name, "attr":"type"}))
 
-    if self.type in ['text','html','xhtml'] and not self.attrs.has_key((None,"src")):
+    if self.type in ['text','html','xhtml'] and (None,"src") not in self.attrs:
       pass
     elif self.type and not self.mime_re.match(self.type):
       self.log(InvalidMIMEType({"parent":self.parent.name, "element":self.name, "attr":"type", "value":self.type}))
@@ -82,12 +82,12 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
         self.validateSafe(self.value)
 
         if self.type.endswith("/html"):
-          if self.value.find("<html")<0 and not self.attrs.has_key((None,"src")):
+          if self.value.find("<html")<0 and (None,"src") not in self.attrs:
             self.log(HtmlFragment({"parent":self.parent.name, "element":self.name,"value":self.value, "type":self.type}))
       else:
         nonhtml.validate(self, ContainsUndeclaredHTML)
 
-    if not self.value and len(self.children)==0 and not self.attrs.has_key((None,"src")):
+    if not self.value and len(self.children)==0 and (None,"src") not in self.attrs:
        self.log(NotBlank({"parent":self.parent.name, "element":self.name}))
 
   def textOK(self):
@@ -96,14 +96,14 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
   def characters(self, string):
     for c in string:
       if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
-        from validators import BadCharacters
+        from .validators import BadCharacters
         self.log(BadCharacters({"parent":self.parent.name, "element":self.name}))
     if (self.type=='xhtml') and string.strip() and not self.value.strip():
       self.log(MissingXhtmlDiv({"parent":self.parent.name, "element":self.name}))
     validatorBase.characters(self,string)
 
   def startElementNS(self, name, qname, attrs):
-    if (self.type<>'xhtml') and not (
+    if (self.type!='xhtml') and not (
         self.type.endswith('+xml') or self.type.endswith('/xml')):
       self.log(UndefinedElement({"parent":self.name, "element":name}))
 
@@ -117,12 +117,12 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
         self.log(NotHtml({"parent":self.parent.name, "element":self.name, "message":"unexpected namespace", "value": qname}))
 
     if self.type=="application/xhtml+xml":
-      if name<>'html':
+      if name!='html':
         self.log(HtmlFragment({"parent":self.parent.name, "element":self.name,"value":self.value, "type":self.type}))
       elif qname not in ["http://www.w3.org/1999/xhtml"]:
         self.log(NotHtml({"parent":self.parent.name, "element":self.name, "message":"unexpected namespace", "value":qname}))
 
-    if self.attrs.has_key((None,"mode")):
+    if (None,"mode") in self.attrs:
       if self.attrs.getValue((None,"mode")) == 'escaped':
         self.log(NotEscaped({"parent":self.parent.name, "element":self.name}))
 
@@ -169,7 +169,7 @@ class diveater(eater):
       for ns,attr in attrs.getNames():
         if not ns and attr not in HTMLValidator.mathml_attributes:
           self.log(SecurityRiskAttr({'attr':attr}))
-    elif namespaces.has_key(qname):
+    elif qname in namespaces:
       if self.name != 'metadata':
         self.log(UndefinedElement({"parent": self.name, "element":namespaces[qname] + ":" + name}))
       self.push(eater(), name, attrs)

--- a/src/feedvalidator/entry.py
+++ b/src/feedvalidator/entry.py
@@ -2,11 +2,11 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
-from logging import *
-from itunes import itunes_item
-from extension import extension_entry
+from .base import validatorBase
+from .validators import *
+from .logging import *
+from .itunes import itunes_item
+from .extension import extension_entry
 
 #
 # pie/echo entry element.
@@ -31,7 +31,7 @@ class entry(validatorBase, extension_entry, itunes_item):
 
     if self.content:
       if not 'summary' in self.children:
-        if self.content.attrs.has_key((None,"src")):
+        if (None,"src") in self.content.attrs:
           self.log(MissingSummary({"parent":self.parent.name, "element":self.name}))
         ctype = self.content.type
         if ctype.find('/') > -1 and not (
@@ -59,27 +59,27 @@ class entry(validatorBase, extension_entry, itunes_item):
     if self.itunes: itunes_item.validate(self)
 
   def do_author(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_category(self):
-    from category import category
+    from .category import category
     return category()
 
   def do_content(self):
-    from content import content
+    from .content import content
     self.content=content()
     return self.content, noduplicates()
 
   def do_contributor(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_id(self):
     return canonicaluri(), nows(), noduplicates(), unique('id',self.parent,DuplicateEntries)
 
   def do_link(self):
-    from link import link
+    from .link import link
     self.links += [link()]
     return self.links[-1]
 
@@ -90,15 +90,15 @@ class entry(validatorBase, extension_entry, itunes_item):
     return source(), noduplicates()
 
   def do_rights(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_summary(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_title(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_updated(self):
@@ -114,7 +114,7 @@ class app_control(validatorBase):
   def do_app_draft(self):
     return yesno(), noduplicates()
 
-from feed import feed
+from .feed import feed
 class source(feed):
   def missingElement(self, params):
     self.log(MissingSourceElement(params))

--- a/src/feedvalidator/extension.py
+++ b/src/feedvalidator/extension.py
@@ -2,8 +2,8 @@ __author__ = "Sam Ruby <http://intertwingly.net>, Mark Pilgrim <http://diveintom
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby, Mark Pilgrim and Phil Ringnalda"
 
-from validators import *
-from logging import *
+from .validators import *
+from .logging import *
 
 ########################################################################
 #                 Extensions that are valid everywhere                 #
@@ -264,7 +264,7 @@ class extension_everywhere:
 #    Extensions that are valid at either the channel or item levels    #
 ########################################################################
 
-from media import media_elements, media_content, media_group
+from .media import media_elements, media_content, media_group
 class extension_channel_item(extension_everywhere, media_elements):
   def do_taxo_topics(self):
     return eater()
@@ -681,7 +681,7 @@ class extension_item(extension_channel_item):
     return media_content()
 
   def do_sx_sync(self):
-    import sse
+    from . import sse
     return sse.Sync()
 
   def do_conversationsNetwork_introMilliseconds(self):
@@ -816,7 +816,7 @@ class access_restriction(enumeration):
   def prevalidate(self):
     self.children.append(True) # force warnings about "mixed" content
 
-    if not self.attrs.has_key((None,"relationship")):
+    if (None,"relationship") not in self.attrs:
       self.log(MissingAttribute({"parent":self.parent.name, "element":self.name, "attr":"relationship"}))
     else:
       self.value=self.attrs.getValue((None,"relationship"))
@@ -898,7 +898,7 @@ class l_link(rdfResourceURI, MimeType):
     self.validate_required_attribute((self.lNS,'rel'), rfc2396_full)
     self.validate_optional_attribute((self.lNS,'title'), nonhtml)
 
-    if self.attrs.has_key((self.lNS, "type")):
+    if (self.lNS, "type") in self.attrs:
       if self.attrs.getValue((self.lNS, "type")).find(':') < 0:
         self.validate_optional_attribute((self.lNS,'type'), MimeType)
       else:
@@ -974,11 +974,11 @@ class extension_channel(extension_channel_item):
     return in_reply_to()
 
   def do_cf_listinfo(self):
-    from cf import listinfo
+    from .cf import listinfo
     return listinfo()
 
   def do_cf_treatAs(self):
-    from cf import treatAs
+    from .cf import treatAs
     return treatAs()
 
   def do_feedburner_awareness(self):
@@ -1012,7 +1012,7 @@ class extension_channel(extension_channel_item):
   do_opensearch10_itemsPerPage = do_opensearch_itemsPerPage
 
   def do_opensearch_Query(self):
-    from opensearch import Query
+    from .opensearch import Query
     return Query()
 
   def do_xhtml_div(self):
@@ -1022,7 +1022,7 @@ class extension_channel(extension_channel_item):
     return xhtml_meta()
 
   def do_sx_sharing(self):
-    import sse
+    from . import sse
     return sse.Sharing()
 
   def do_fh_archive(self):
@@ -1206,22 +1206,22 @@ class in_reply_to(canonicaluri, xmlbase):
     return [(None, u'href'), (None, u'ref'), (None, u'source'), (None, u'type')]
 
   def validate(self):
-    if self.attrs.has_key((None, "href")):
+    if (None, "href") in self.attrs:
       self.value = self.attrs.getValue((None, "href"))
       self.name = "href"
       xmlbase.validate(self)
 
-    if self.attrs.has_key((None, "ref")):
+    if (None, "ref") in self.attrs:
       self.value = self.attrs.getValue((None, "ref"))
       self.name = "ref"
       canonicaluri.validate(self)
 
-    if self.attrs.has_key((None, "source")):
+    if (None, "source") in self.attrs:
       self.value = self.attrs.getValue((None, "source"))
       self.name = "source"
       xmlbase.validate(self)
 
-    if self.attrs.has_key((None, "type")):
+    if (None, "type") in self.attrs:
       self.value = self.attrs.getValue((None, "type"))
       if not mime_re.match(self.value):
         self.log(InvalidMIMEType({"parent":self.parent.name, "element":self.name, "attr":"type", "value":self.value}))
@@ -1236,23 +1236,23 @@ class Questionable(extension_everywhere):
   children = []
 
   def do_atom_author(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_atom_category(self):
-    from category import category
+    from .category import category
     return category()
 
   def do_atom_content(self):
-    from content import content
+    from .content import content
     return content()
 
   def do_atom_contributor(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_atom_generator(self):
-    from generator import generator
+    from .generator import generator
     return generator()
 
   def do_atom_icon(self):
@@ -1262,7 +1262,7 @@ class Questionable(extension_everywhere):
     return canonicaluri(), noduplicates()
 
   def do_atom_link(self):
-    from link import link
+    from .link import link
     return link()
 
   def do_atom_logo(self):
@@ -1272,32 +1272,32 @@ class Questionable(extension_everywhere):
     return rfc3339(), noduplicates()
 
   def do_atom_rights(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_subtitle(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_summary(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_title(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_updated(self):
     return rfc3339(), noduplicates()
 
   def do_app_workspace(self):
-    from service import workspace
+    from .service import workspace
     return workspace()
 
   def do_app_collection(self):
-    from service import collection
+    from .service import collection
     return collection()
 
   def do_app_categories(self):
-    from categories import categories
+    from .categories import categories
     return categories()

--- a/src/feedvalidator/feed.py
+++ b/src/feedvalidator/feed.py
@@ -2,11 +2,11 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
-from logging import *
-from itunes import itunes_channel
-from extension import extension_feed
+from .base import validatorBase
+from .validators import *
+from .logging import *
+from .itunes import itunes_channel
+from .extension import extension_feed
 
 #
 # Atom root element
@@ -111,22 +111,22 @@ class feed(validatorBase, extension_feed, itunes_channel):
 
   def do_author(self):
     self.metadata()
-    from author import author
+    from .author import author
     return author()
 
   def do_category(self):
     self.metadata()
-    from category import category
+    from .category import category
     return category()
 
   def do_contributor(self):
     self.metadata()
-    from author import author
+    from .author import author
     return author()
 
   def do_generator(self):
     self.metadata()
-    from generator import generator
+    from .generator import generator
     return generator(), nonblank(), noduplicates()
 
   def do_id(self):
@@ -139,7 +139,7 @@ class feed(validatorBase, extension_feed, itunes_channel):
 
   def do_link(self):
     self.metadata()
-    from link import link
+    from .link import link
     self.links.append(link())
     return self.links[-1]
 
@@ -149,17 +149,17 @@ class feed(validatorBase, extension_feed, itunes_channel):
 
   def do_title(self):
     self.metadata()
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_subtitle(self):
     self.metadata()
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_rights(self):
     self.metadata()
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_updated(self):
@@ -169,9 +169,9 @@ class feed(validatorBase, extension_feed, itunes_channel):
   def do_entry(self):
     if not 'entry' in self.children:
       self.validate_metadata()
-    from entry import entry
+    from .entry import entry
     return entry()
 
   def do_app_collection(self):
-    from service import collection
+    from .service import collection
     return collection(), noduplicates()

--- a/src/feedvalidator/formatter/application_test.py
+++ b/src/feedvalidator/formatter/application_test.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 """Output class for testing that all output messages are defined properly"""
 
-from base import BaseFormatter
+from .base import BaseFormatter
 import feedvalidator
 import os
 LANGUAGE = os.environ.get('LANGUAGE', 'en_US:en').split(':')[1]
@@ -14,7 +14,7 @@ class Formatter(BaseFormatter):
   def getMessage(self, event):
     classes = [event.__class__]
     while len(classes):
-      if lang.messages.has_key(classes[0]):
+      if classes[0] in lang.messages:
         return lang.messages[classes[0]] % event.params
       classes = classes + list(classes[0].__bases__)
       del classes[0]

--- a/src/feedvalidator/formatter/base.py
+++ b/src/feedvalidator/formatter/base.py
@@ -22,11 +22,11 @@ class BaseFormatter(UserList):
     return [self.format(msg) for msg in self.data if isinstance(msg,Warning)]
 
   def getLine(self, event):
-    if not event.params.has_key('line'): return ''
+    if 'line' not in event.params: return ''
     return lang.line % event.params
 
   def getColumn(self, event):
-    if not event.params.has_key('column'): return ''
+    if 'column' not in event.params: return ''
     return lang.column % event.params
 
   def getLineAndColumn(self, event):
@@ -36,7 +36,7 @@ class BaseFormatter(UserList):
     return '%s, %s:' % (line, column)
 
   def getCount(self, event):
-    if not event.params.has_key('msgcount'): return ''
+    if 'msgcount' not in event.params: return ''
     count = int(event.params['msgcount'])
     if count <= 1: return ''
     return lang.occurances % event.params
@@ -44,7 +44,7 @@ class BaseFormatter(UserList):
   def getMessageClass(self, event):
     classes = [event.__class__]
     while len(classes):
-      if lang.messages.has_key(classes[0]):
+      if classes[0] in lang.messages:
         return classes[0]
       classes = classes + list(classes[0].__bases__)
       del classes[0]
@@ -53,7 +53,7 @@ class BaseFormatter(UserList):
   def getMessage(self, event):
     classes = [event.__class__]
     while len(classes):
-      if lang.messages.has_key(classes[0]):
+      if classes[0] in lang.messages:
         try:
           return lang.messages[classes[0]] % event.params
         except:
@@ -64,4 +64,4 @@ class BaseFormatter(UserList):
 
   def format(self, event):
     """returns the formatted representation of a single event"""
-    return `event`
+    return repr(event)

--- a/src/feedvalidator/formatter/text_html.py
+++ b/src/feedvalidator/formatter/text_html.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 """Output class for HTML text output"""
 
-from base import BaseFormatter
+from .base import BaseFormatter
 import feedvalidator
 from xml.sax.saxutils import escape
 
@@ -67,7 +67,7 @@ class Formatter(BaseFormatter):
     return '</ul>'
 
   def format(self, event):
-    if event.params.has_key('line'):
+    if 'line' in event.params:
       line = event.params['line']
       if line >= len(self.rawdata.split('\n')):
         # For some odd reason, UnicodeErrors tend to trigger a bug

--- a/src/feedvalidator/formatter/text_plain.py
+++ b/src/feedvalidator/formatter/text_plain.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 """Output class for plain text output"""
 
-from base import BaseFormatter
+from .base import BaseFormatter
 import feedvalidator
 
 class Formatter(BaseFormatter):

--- a/src/feedvalidator/formatter/text_xml.py
+++ b/src/feedvalidator/formatter/text_xml.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 """Output class for xml output"""
 
-from base import BaseFormatter
+from .base import BaseFormatter
 from feedvalidator.logging import *
 import feedvalidator
 

--- a/src/feedvalidator/generator.py
+++ b/src/feedvalidator/generator.py
@@ -2,8 +2,8 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
+from .base import validatorBase
+from .validators import *
 
 #
 # Atom generator element
@@ -13,10 +13,10 @@ class generator(nonhtml,rfc2396):
     return [(None, u'uri'), (None, u'version')]
 
   def prevalidate(self):
-    if self.attrs.has_key((None, "url")):
+    if (None, "url") in self.attrs:
       self.value = self.attrs.getValue((None, "url"))
       rfc2396.validate(self, extraParams={"attr": "url"})
-    if self.attrs.has_key((None, "uri")):
+    if (None, "uri") in self.attrs:
       self.value = self.attrs.getValue((None, "uri"))
       rfc2396.validate(self, errorClass=InvalidURIAttribute, extraParams={"attr": "uri"})
     self.value=''

--- a/src/feedvalidator/i18n/en.py
+++ b/src/feedvalidator/i18n/en.py
@@ -261,5 +261,5 @@ messages = {
   MissingByAndWhenAttrs:   "Missing by and when attributes",
   QuestionableUsage:       "Undocumented use of %(element)s",
   InvalidRSSVersion:       "Invalid RSS Version",
-  HttpErrorWithPossibleFeed:	"HTTP error with content that looks like a feed",
+  HttpErrorWithPossibleFeed:    "HTTP error with content that looks like a feed",
  }

--- a/src/feedvalidator/image.py
+++ b/src/feedvalidator/image.py
@@ -2,9 +2,9 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
-from extension import extension_everywhere
+from .base import validatorBase
+from .validators import *
+from .extension import extension_everywhere
 
 #
 # image element.
@@ -17,13 +17,13 @@ class image(validatorBase, extension_everywhere):
   def validate(self):
     if self.value.strip():
       self.log(UnexpectedText({"parent":self.parent.name, "element":"image"}))
-    if self.attrs.has_key((rdfNS,"resource")):
+    if (rdfNS,"resource") in self.attrs:
       return # looks like an RSS 1.0 feed
     if not "title" in self.children:
       self.log(MissingTitle({"parent":self.name, "element":"title"}))
     if not "url" in self.children:
       self.log(MissingElement({"parent":self.name, "element":"url"}))
-    if self.attrs.has_key((rdfNS,"parseType")):
+    if (rdfNS,"parseType") in self.attrs:
       return # looks like an RSS 1.1 feed
     if not "link" in self.children:
       self.log(MissingLink({"parent":self.name, "element":"link"}))

--- a/src/feedvalidator/item.py
+++ b/src/feedvalidator/item.py
@@ -2,11 +2,11 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
-from logging import *
-from itunes import itunes_item
-from extension import *
+from .base import validatorBase
+from .validators import *
+from .logging import *
+from .itunes import itunes_item
+from .extension import *
 
 #
 # item element.
@@ -61,27 +61,27 @@ class item(validatorBase, extension_item, itunes_item):
     return rfc2396_full(), noduplicates(), unique('atom_id',self.parent)
 
   def do_atom_link(self):
-    from link import link
+    from .link import link
     return link()
 
   def do_atom_title(self):
-    from content import content
+    from .content import content
     return content(), noduplicates()
 
   def do_atom_summary(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_atom_author(self):
-    from author import author
+    from .author import author
     return author(), noduplicates()
 
   def do_atom_contributor(self):
-    from author import author
+    from .author import author
     return author()
 
   def do_atom_content(self):
-    from content import content
+    from .content import content
     return content()
 
   def do_atom_published(self):
@@ -168,7 +168,7 @@ class rss10Item(item, extension_rss10_item):
       return text()
 
   def prevalidate(self):
-    if self.attrs.has_key((rdfNS,"about")):
+    if (rdfNS,"about") in self.attrs:
       about = self.attrs[(rdfNS,"about")]
       if not "abouts" in self.dispatcher.__dict__:
         self.dispatcher.__dict__["abouts"] = []
@@ -182,7 +182,7 @@ class rss10Item(item, extension_rss10_item):
 # items element.
 #
 class items(validatorBase):
-  from root import rss11_namespace as rss11_ns
+  from .root import rss11_namespace as rss11_ns
 
   def getExpectedAttrNames(self):
     return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')]
@@ -218,7 +218,7 @@ class source(nonhtml):
     return text.prevalidate(self)
 
 class enclosure(validatorBase):
-  from validators import mime_re
+  from .validators import mime_re
   def getExpectedAttrNames(self):
     return [(None, u'url'), (None, u'length'), (None, u'type')]
   def prevalidate(self):
@@ -244,7 +244,7 @@ class enclosure(validatorBase):
       self.log(MissingAttribute({"parent":self.parent.name, "element":self.name, "attr":'type'}))
 
     self.validate_required_attribute((None,'url'), httpURL)
-    if self.attrs.has_key((None,u"url")):
+    if (None,u"url") in self.attrs:
       if hasattr(self.parent,'setEnclosure'):
         self.parent.setEnclosure(self.attrs.getValue((None, 'url')))
 

--- a/src/feedvalidator/itunes.py
+++ b/src/feedvalidator/itunes.py
@@ -2,7 +2,7 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from validators import *
+from .validators import *
 
 class itunes:
   def do_itunes_author(self):
@@ -27,7 +27,7 @@ class itunes:
     return image(), noduplicates()
 
 class itunes_channel(itunes):
-  from logging import MissingItunesElement
+  from .logging import MissingItunesElement
 
   def validate(self):
     if not 'language' in self.children and not self.xmlLang:
@@ -42,7 +42,7 @@ class itunes_channel(itunes):
   def setItunes(self, value):
     if value and not self.itunes:
       if self.dispatcher.encoding.lower() not in ['utf-8','utf8']:
-        from logging import NotUTF8
+        from .logging import NotUTF8
         self.log(NotUTF8({"parent":self.parent.name, "element":self.name}))
       if self.getFeedType() == TYPE_ATOM and 'entry' in self.children:
         self.validate()
@@ -83,7 +83,7 @@ class itunes_item(itunes):
       # http://www.apple.com/itunes/podcasts/techspecs.html#_Toc526931678
       ext = url.split('.')[-1]
       if ext not in itunes_item.supported_formats:
-        from logging import UnsupportedItunesFormat
+        from .logging import UnsupportedItunesFormat
         self.log(UnsupportedItunesFormat({"parent":self.parent.name, "element":self.name, "extension":ext}))
 
     if not hasattr(self, 'enclosures'): self.enclosures = []

--- a/src/feedvalidator/kml.py
+++ b/src/feedvalidator/kml.py
@@ -2,8 +2,8 @@ __author__ = "Gregor J. Rothfuss <http://greg.abstrakt.ch/> and Mark Pilgrim <ht
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
+from .base import validatorBase
+from .validators import *
 import re
 
 # This code tries to mimic the structure of the canonical KML XSD as much as possible.
@@ -68,11 +68,11 @@ class FeatureType(validatorBase):
     return Metadata()
 
   def do_atom_link(self):
-    from link import link
+    from .link import link
     return link()
 
   def do_atom_author(self):
-    from author import author
+    from .author import author
     return author()
 
 # OverlayType from the XSD schema
@@ -218,7 +218,7 @@ class LookAtType(Feature):
 # KML element.
 #
 class kml(validatorBase, Container, Feature):
-  from logging import TYPE_KML20, TYPE_KML21, TYPE_KML22
+  from .logging import TYPE_KML20, TYPE_KML21, TYPE_KML22
 
   def do_NetworkLink(self):
     return NetworkLink()
@@ -233,11 +233,11 @@ class kml(validatorBase, Container, Feature):
     return NetworkLinkControl()
 
   def do_atom_link(self):
-    from link import link
+    from .link import link
     return link()
 
   def do_atom_author(self):
-    from author import author
+    from .author import author
     return author()
 
 class NetworkLinkControl(validatorBase):
@@ -361,7 +361,7 @@ class SchemaField(validatorBase):
 
 class Placemark(validatorBase, FeatureType, Geometry):
   def prevalidate(self):
-    if not self.attrs.has_key((None,"id")):
+    if (None,"id") not in self.attrs:
       self.log(MissingId({"parent":self.name, "element":"id"}))
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 

--- a/src/feedvalidator/link.py
+++ b/src/feedvalidator/link.py
@@ -2,8 +2,8 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
+from .base import validatorBase
+from .validators import *
 
 #
 # Atom link element
@@ -60,7 +60,7 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
     self.hreflang = ""
     self.title = ""
 
-    if self.attrs.has_key((None, "rel")):
+    if (None, "rel") in self.attrs:
       self.value = self.rel = self.attrs.getValue((None, "rel"))
 
       if self.rel.startswith('http://www.iana.org/assignments/relation/'):
@@ -77,7 +77,7 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
       if self.rel in self.rfc5005 and self.parent.name == 'entry':
         self.log(FeedHistoryRelInEntry({"rel":self.rel}))
 
-    if self.attrs.has_key((None, "type")):
+    if (None, "type") in self.attrs:
       self.value = self.type = self.attrs.getValue((None, "type"))
       if not mime_re.match(self.type):
         self.log(InvalidMIMEType({"parent":self.parent.name, "element":self.name, "attr":"type", "value":self.type}))
@@ -86,24 +86,24 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
       else:
         self.log(ValidMIMEAttribute({"parent":self.parent.name, "element":self.name, "attr":"type", "value":self.type}))
 
-    if self.attrs.has_key((None, "title")):
+    if (None, "title") in self.attrs:
       self.log(ValidTitle({"parent":self.parent.name, "element":self.name, "attr":"title"}))
       self.value = self.title = self.attrs.getValue((None, "title"))
       nonblank.validate(self, errorClass=AttrNotBlank, extraParams={"attr": "title"})
       nonhtml.validate(self)
 
-    if self.attrs.has_key((None, "length")):
+    if (None, "length") in self.attrs:
       self.name = 'length'
       self.value = self.attrs.getValue((None, "length"))
       nonNegativeInteger.validate(self)
       nonblank.validate(self)
 
-    if self.attrs.has_key((None, "hreflang")):
+    if (None, "hreflang") in self.attrs:
       self.name = 'hreflang'
       self.value = self.hreflang = self.attrs.getValue((None, "hreflang"))
       iso639.validate(self)
 
-    if self.attrs.has_key((None, "href")):
+    if (None, "href") in self.attrs:
       self.name = 'href'
       self.value = self.href = self.attrs.getValue((None, "href"))
       xmlbase.validate(self, extraParams={"attr": "href"})
@@ -117,7 +117,7 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
         element = self
         while not absolute and element and hasattr(element,'attrs'):
           pattrs = element.attrs
-          if pattrs and pattrs.has_key((XML_NAMESPACE, u'base')):
+          if pattrs and (XML_NAMESPACE, u'base') in pattrs:
             absolute=urlparse(pattrs.getValue((XML_NAMESPACE, u'base')))[1]
           element = element.parent
         if not absolute:
@@ -126,7 +126,7 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
         from urlparse import urljoin
         if urljoin(self.xmlBase,self.value) not in self.dispatcher.selfURIs:
           if urljoin(self.xmlBase,self.value).split('#')[0] != self.xmlBase.split('#')[0]:
-            from uri import Uri
+            from .uri import Uri
             if self.value.startswith('http://feeds.feedburner.com/'):
               if self.value.endswith('?format=xml'):
                 self.value = self.value.split('?')[0]
@@ -145,17 +145,17 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
     else:
       self.log(MissingHref({"parent":self.parent.name, "element":self.name, "attr":"href"}))
 
-    if self.attrs.has_key((u'http://purl.org/syndication/thread/1.0', u'count')):
+    if (u'http://purl.org/syndication/thread/1.0', u'count') in self.attrs:
       if self.rel != "replies":
         self.log(UnexpectedAttribute({"parent":self.parent.name, "element":self.name, "attribute":"thr:count"}))
       self.value = self.attrs.getValue((u'http://purl.org/syndication/thread/1.0', u'count'))
       self.name="thr:count"
       nonNegativeInteger.validate(self)
 
-    if self.attrs.has_key((u'http://purl.org/syndication/thread/1.0', u'when')):
+    if (u'http://purl.org/syndication/thread/1.0', u'when') in self.attrs:
         self.log(NoThrWhen({"parent":self.parent.name, "element":self.name, "attribute":"thr:when"}))
 
-    if self.attrs.has_key((u'http://purl.org/syndication/thread/1.0', u'updated')):
+    if (u'http://purl.org/syndication/thread/1.0', u'updated') in self.attrs:
       if self.rel != "replies":
         self.log(UnexpectedAttribute({"parent":self.parent.name, "element":self.name, "attribute":"thr:updated"}))
       self.value = self.attrs.getValue((u'http://purl.org/syndication/thread/1.0', u'updated'))

--- a/src/feedvalidator/media.py
+++ b/src/feedvalidator/media.py
@@ -1,4 +1,4 @@
-from validators import *
+from .validators import *
 
 class media_elements:
   def do_media_adult(self):
@@ -269,7 +269,7 @@ class media_thumbnail(validatorBase,positiveInteger,rfc2396_full):
     self.name = "width"
     if self.value: positiveInteger.validate(self)
 
-from extension import extension_everywhere
+from .extension import extension_everywhere
 class media_content(validatorBase, media_elements, extension_everywhere,
     positiveInteger, rfc2396_full, truefalse, nonNegativeInteger):
   def getExpectedAttrNames(self):

--- a/src/feedvalidator/mediaTypes.py
+++ b/src/feedvalidator/mediaTypes.py
@@ -7,7 +7,7 @@ __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2004 Joseph Walton"
 
 from cgi import parse_header
-from logging import *
+from .logging import *
 
 FEED_TYPES = [
   'text/xml', 'application/xml', 'application/rss+xml', 'application/rdf+xml',
@@ -85,5 +85,5 @@ def contentSniffing(mediaType, rawdata, loggedEvents):
       block.find('http://www.w3.org/1999/02/22-rdf-syntax-ns#') >= 0 and
       block.find( 'http://purl.org/rss/1.0/')): return
 
-  from logging import NonSpecificMediaType
+  from .logging import NonSpecificMediaType
   loggedEvents.append(NonSpecificMediaType({"contentType": mediaType}))

--- a/src/feedvalidator/opensearch.py
+++ b/src/feedvalidator/opensearch.py
@@ -1,5 +1,5 @@
-from validators import *
-from logging import *
+from .validators import *
+from .logging import *
 import re
 
 class OpenSearchDescription(validatorBase):
@@ -103,7 +103,7 @@ class Query(validatorBase):
     self.validate_optional_attribute((None,'inputEncoding'), Charset)
     self.validate_optional_attribute((None,'outputEncoding'), Charset)
 
-    if self.attrs.has_key((None,"role")) and \
+    if (None,"role") in self.attrs and \
       self.attrs.getValue((None,"role")) == "example":
       self.parent.exampleFound = 1
 

--- a/src/feedvalidator/opml.py
+++ b/src/feedvalidator/opml.py
@@ -2,10 +2,10 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import *
-from logging import *
-from extension import extension_everywhere
+from .base import validatorBase
+from .validators import *
+from .logging import *
+from .extension import extension_everywhere
 import re
 
 #

--- a/src/feedvalidator/rdf.py
+++ b/src/feedvalidator/rdf.py
@@ -2,11 +2,11 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from logging import *
-from validators import rdfAbout, noduplicates, text, eater
-from root import rss11_namespace as rss11_ns
-from extension import extension_everywhere
+from .base import validatorBase
+from .logging import *
+from .validators import rdfAbout, noduplicates, text, eater
+from .root import rss11_namespace as rss11_ns
+from .extension import extension_everywhere
 
 rdfNS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
@@ -16,12 +16,12 @@ rdfNS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 class rdf(validatorBase,object):
 
   def do_rss090_channel(self):
-    from channel import channel
+    from .channel import channel
     self.dispatcher.defaultNamespaces.append("http://my.netscape.com/rdf/simple/0.9/")
     return channel(), noduplicates()
 
   def do_channel(self):
-    from channel import rss10Channel
+    from .channel import rss10Channel
     return rdfAbout(), rss10Channel(), noduplicates()
 
   def _is_090(self):
@@ -34,11 +34,11 @@ class rdf(validatorBase,object):
       return v, rdfAbout()
 
   def do_item(self):
-    from item import rss10Item
+    from .item import rss10Item
     return self._withAbout(rss10Item())
 
   def do_textinput(self):
-    from textInput import textInput
+    from .textInput import textInput
     return self._withAbout(textInput())
 
   def do_image(self):
@@ -60,7 +60,7 @@ class rdf(validatorBase,object):
     if not "channel" in self.children and not "rss090_channel" in self.children:
       self.log(MissingElement({"parent":self.name.replace('_',':'), "element":"channel"}))
 
-from validators import rfc2396_full
+from .validators import rfc2396_full
 
 class rss10Image(validatorBase, extension_everywhere):
   def validate(self):
@@ -72,7 +72,7 @@ class rss10Image(validatorBase, extension_everywhere):
       self.log(MissingElement({"parent":self.name, "element":"url"}))
 
   def do_title(self):
-    from image import title
+    from .image import title
     return title(), noduplicates()
 
   def do_link(self):
@@ -88,7 +88,7 @@ class rss10Image(validatorBase, extension_everywhere):
     return text() # duplicates allowed
 
   def do_dc_date(self):
-    from validators import w3cdtf
+    from .validators import w3cdtf
     return w3cdtf(), noduplicates()
 
   def do_cc_license(self):
@@ -109,18 +109,18 @@ class rdfExtension(validatorBase):
   def setElement(self, name, attrs, parent):
     validatorBase.setElement(self, name, attrs, parent)
 
-    if attrs.has_key((rdfNS,"parseType")):
+    if (rdfNS,"parseType") in attrs:
       if attrs[(rdfNS,"parseType")] == "Literal": self.literal=True
 
     if not self.literal:
 
       # ensure no rss11 children
       if self.qname==rss11_ns:
-        from logging import UndefinedElement
+        from .logging import UndefinedElement
         self.log(UndefinedElement({"parent":parent.name, "element":name}))
 
       # no duplicate rdf:abouts
-      if attrs.has_key((rdfNS,"about")):
+      if (rdfNS,"about") in attrs:
         about = attrs[(rdfNS,"about")]
         if not "abouts" in self.dispatcher.__dict__:
           self.dispatcher.__dict__["abouts"] = []
@@ -143,13 +143,13 @@ class rdfExtension(validatorBase):
   def startElementNS(self, name, qname, attrs):
     # ensure element is "namespace well formed"
     if name.find(':') != -1:
-      from logging import MissingNamespace
+      from .logging import MissingNamespace
       self.log(MissingNamespace({"parent":self.name, "element":name}))
 
     # ensure all attribute namespaces are properly defined
     for (namespace,attr) in attrs.keys():
       if ':' in attr and not namespace:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":self.name, "element":attr}))
 
     # eat children

--- a/src/feedvalidator/root.py
+++ b/src/feedvalidator/root.py
@@ -60,7 +60,7 @@ class root(validatorBase):
           from .logging import TYPE_ATOM_ENTRY
           self.setFeedType(TYPE_ATOM_ENTRY)
         self.dispatcher.defaultNamespaces.append(atom_namespace)
-        if qname!=atom_namespace:
+        if qname != atom_namespace:
           from .logging import InvalidNamespace
           self.log(InvalidNamespace({"parent":"root", "element":name, "namespace":qname}))
           self.dispatcher.defaultNamespaces.append(qname)

--- a/src/feedvalidator/root.py
+++ b/src/feedvalidator/root.py
@@ -2,7 +2,7 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
+from .base import validatorBase
 
 rss11_namespace='http://purl.org/net/rss1.1#'
 purl1_namespace='http://purl.org/rss/1.0/'
@@ -32,56 +32,56 @@ class root(validatorBase):
   def startElementNS(self, name, qname, attrs):
     if name=='rss':
       if qname:
-        from logging import InvalidNamespace
+        from .logging import InvalidNamespace
         self.log(InvalidNamespace({"parent":"root", "element":name, "namespace":qname}))
         self.dispatcher.defaultNamespaces.append(qname)
 
     if name=='feed' or name=='entry':
-      if self.namespace.has_key('atom'):
-        from logging import AvoidNamespacePrefix
+      if 'atom' in self.namespace:
+        from .logging import AvoidNamespacePrefix
         self.log(AvoidNamespacePrefix({'prefix':'atom'}))
-      if self.namespace.has_key('xhtml'):
-        from logging import AvoidNamespacePrefix
+      if 'xhtml' in self.namespace:
+        from .logging import AvoidNamespacePrefix
         self.log(AvoidNamespacePrefix({'prefix':'xhtml'}))
       if qname==pie_namespace:
-        from logging import ObsoleteNamespace
+        from .logging import ObsoleteNamespace
         self.log(ObsoleteNamespace({"element":"feed"}))
         self.dispatcher.defaultNamespaces.append(pie_namespace)
-        from logging import TYPE_ATOM
+        from .logging import TYPE_ATOM
         self.setFeedType(TYPE_ATOM)
       elif not qname:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":"root", "element":name}))
       else:
         if name=='feed':
-          from logging import TYPE_ATOM
+          from .logging import TYPE_ATOM
           self.setFeedType(TYPE_ATOM)
         else:
-          from logging import TYPE_ATOM_ENTRY
+          from .logging import TYPE_ATOM_ENTRY
           self.setFeedType(TYPE_ATOM_ENTRY)
         self.dispatcher.defaultNamespaces.append(atom_namespace)
-        if qname<>atom_namespace:
-          from logging import InvalidNamespace
+        if qname!=atom_namespace:
+          from .logging import InvalidNamespace
           self.log(InvalidNamespace({"parent":"root", "element":name, "namespace":qname}))
           self.dispatcher.defaultNamespaces.append(qname)
 
     if name=='Channel':
       if not qname:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":"root", "element":name}))
       elif qname != rss11_namespace :
-        from logging import InvalidNamespace
+        from .logging import InvalidNamespace
         self.log(InvalidNamespace({"parent":"root", "element":name, "namespace":qname}))
       else:
         self.dispatcher.defaultNamespaces.append(qname)
-        from logging import TYPE_RSS1
+        from .logging import TYPE_RSS1
         self.setFeedType(TYPE_RSS1)
 
     if name=='kml':
-      from logging import TYPE_KML20, TYPE_KML21, TYPE_KML22
+      from .logging import TYPE_KML20, TYPE_KML21, TYPE_KML22
       self.dispatcher.defaultNamespaces.append(qname)
       if not qname:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":"root", "element":name}))
         qname = kml20_namespace
         feedType = TYPE_KML20
@@ -92,7 +92,7 @@ class root(validatorBase):
       elif qname == kml22_namespace:
         feedType = TYPE_KML22
       elif qname != kml20_namespace and qname != kml21_namespace and qname != kml22_namespace:
-        from logging import InvalidNamespace
+        from .logging import InvalidNamespace
         self.log(InvalidNamespace({"element":name, "namespace":qname}))
         qname = kml22_namespace
         feedType = TYPE_KML22
@@ -100,24 +100,24 @@ class root(validatorBase):
 
     if name=='OpenSearchDescription':
       if not qname:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":"root", "element":name}))
         qname = opensearch_namespace
       elif qname != opensearch_namespace:
-        from logging import InvalidNamespace
+        from .logging import InvalidNamespace
         self.log(InvalidNamespace({"element":name, "namespace":qname}))
         self.dispatcher.defaultNamespaces.append(qname)
         qname = opensearch_namespace
 
     if name=='XRDS':
-      from logging import TYPE_XRD
+      from .logging import TYPE_XRD
       self.setFeedType(TYPE_XRD)
       if not qname:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":"root", "element":name}))
         qname = xrds_namespace
       elif qname != xrds_namespace:
-        from logging import InvalidNamespace
+        from .logging import InvalidNamespace
         self.log(InvalidNamespace({"element":name, "namespace":qname}))
         self.dispatcher.defaultNamespaces.append(qname)
         qname = xrds_namespace
@@ -125,7 +125,7 @@ class root(validatorBase):
     validatorBase.startElementNS(self, name, qname, attrs)
 
   def unknown_starttag(self, name, qname, attrs):
-    from logging import ObsoleteNamespace,InvalidNamespace,UndefinedElement
+    from .logging import ObsoleteNamespace,InvalidNamespace,UndefinedElement
     if qname in ['http://example.com/newformat#','http://purl.org/atom/ns#']:
       self.log(ObsoleteNamespace({"element":name, "namespace":qname}))
     elif name=='feed':
@@ -133,69 +133,69 @@ class root(validatorBase):
     else:
       self.log(UndefinedElement({"parent":"root", "element":name}))
 
-    from validators import any
+    from .validators import any
     return any(self, name, qname, attrs)
 
   def do_rss(self):
-    from rss import rss
+    from .rss import rss
     return rss()
 
   def do_feed(self):
-    from feed import feed
+    from .feed import feed
     if pie_namespace in self.dispatcher.defaultNamespaces:
-      from validators import eater
+      from .validators import eater
       return eater()
     return feed()
 
   def do_entry(self):
-    from entry import entry
+    from .entry import entry
     return entry()
 
   def do_app_categories(self):
-    from logging import TYPE_APP_CATEGORIES
+    from .logging import TYPE_APP_CATEGORIES
     self.setFeedType(TYPE_APP_CATEGORIES)
-    from categories import categories
+    from .categories import categories
     return categories()
 
   def do_app_service(self):
-    from logging import TYPE_APP_SERVICE
+    from .logging import TYPE_APP_SERVICE
     self.setFeedType(TYPE_APP_SERVICE)
-    from service import service
+    from .service import service
     return service()
 
   def do_kml(self):
-    from kml import kml
+    from .kml import kml
     return kml()
 
   def do_opml(self):
-    from opml import opml
+    from .opml import opml
     return opml()
 
   def do_outlineDocument(self):
-    from logging import ObsoleteVersion
+    from .logging import ObsoleteVersion
     self.log(ObsoleteVersion({"element":"outlineDocument"}))
 
-    from opml import opml
+    from .opml import opml
     return opml()
 
   def do_opensearch_OpenSearchDescription(self):
-    import opensearch
+    from . import opensearch
     self.dispatcher.defaultNamespaces.append(opensearch_namespace)
-    from logging import TYPE_OPENSEARCH
+    from .logging import TYPE_OPENSEARCH
     self.setFeedType(TYPE_OPENSEARCH)
     return opensearch.OpenSearchDescription()
 
   def do_xrds_XRDS(self):
-    from xrd import xrds
+    from .xrd import xrds
     return xrds()
 
   def do_rdf_RDF(self):
-    from rdf import rdf
+    from .rdf import rdf
     self.dispatcher.defaultNamespaces.append(purl1_namespace)
     return rdf()
 
   def do_Channel(self):
-    from channel import rss10Channel
+    from .channel import rss10Channel
     return rss10Channel()
 
   def do_soap_Envelope(self):
@@ -209,7 +209,7 @@ class root(validatorBase):
     return root(self, self.xmlBase)
 
   def do_xhtml_html(self):
-    from logging import UndefinedElement
+    from .logging import UndefinedElement
     self.log(UndefinedElement({"parent":"root", "element":"xhtml:html"}))
-    from validators import eater
+    from .validators import eater
     return eater()

--- a/src/feedvalidator/rss.py
+++ b/src/feedvalidator/rss.py
@@ -2,20 +2,20 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from logging import *
-from validators import noduplicates
+from .base import validatorBase
+from .logging import *
+from .validators import noduplicates
 
 #
 # Rss element.  The only valid child element is "channel"
 #
 class rss(validatorBase):
   def do_channel(self):
-    from channel import rss20Channel
+    from .channel import rss20Channel
     return rss20Channel(), noduplicates()
 
   def do_access_restriction(self):
-    from extension import access_restriction
+    from .extension import access_restriction
     return access_restriction(), noduplicates()
 
   def getExpectedAttrNames(self):
@@ -28,7 +28,7 @@ class rss(validatorBase):
       self.log(MissingAttribute({"parent":self.parent.name, "element":self.name, "attr":"version"}))
     elif [e for e in self.dispatcher.loggedEvents if e.__class__==ValidDoctype]:
       self.version = self.attrs[(None,'version')]
-      if self.attrs[(None,'version')]<>'0.91':
+      if self.attrs[(None,'version')]!='0.91':
         self.log(InvalidDoctype({"parent":self.parent.name, "element":self.name, "attr":"version"}))
     else:
       self.version = self.attrs[(None,'version')]

--- a/src/feedvalidator/rss.py
+++ b/src/feedvalidator/rss.py
@@ -28,7 +28,7 @@ class rss(validatorBase):
       self.log(MissingAttribute({"parent":self.parent.name, "element":self.name, "attr":"version"}))
     elif [e for e in self.dispatcher.loggedEvents if e.__class__==ValidDoctype]:
       self.version = self.attrs[(None,'version')]
-      if self.attrs[(None,'version')]!='0.91':
+      if self.attrs[(None,'version')] != '0.91':
         self.log(InvalidDoctype({"parent":self.parent.name, "element":self.name, "attr":"version"}))
     else:
       self.version = self.attrs[(None,'version')]

--- a/src/feedvalidator/service.py
+++ b/src/feedvalidator/service.py
@@ -1,6 +1,6 @@
-from base import validatorBase
-from validators import *
-from extension import extension_everywhere
+from .base import validatorBase
+from .validators import *
+from .extension import extension_everywhere
 
 class service(validatorBase, extension_everywhere):
   def getExpectedAttrNames(self):
@@ -22,7 +22,7 @@ class workspace(validatorBase, extension_everywhere):
     return collection()
 
   def do_atom_title(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
 class collection(validatorBase, extension_everywhere):
@@ -37,19 +37,19 @@ class collection(validatorBase, extension_everywhere):
       self.log(MissingElement({"parent":self.name, "element":"atom:title"}))
 
   def do_atom_title(self):
-    from content import textConstruct
+    from .content import textConstruct
     return textConstruct(), noduplicates()
 
   def do_title(self):
-    from root import atom_namespace
+    from .root import atom_namespace
     assert(atom_namespace in self.dispatcher.defaultNamespaces)
     self.child = 'atom_title'
     return self.do_atom_title()
 
   def do_app_categories(self):
-    from categories import categories
+    from .categories import categories
     return categories()
 
   def do_app_accept(self):
-    from categories import categories
+    from .categories import categories
     return MediaRange()

--- a/src/feedvalidator/skipDays.py
+++ b/src/feedvalidator/skipDays.py
@@ -2,9 +2,9 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import text
-from logging import *
+from .base import validatorBase
+from .validators import text
+from .logging import *
 
 #
 # skipDays element

--- a/src/feedvalidator/skipHours.py
+++ b/src/feedvalidator/skipHours.py
@@ -2,9 +2,9 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from validators import text
-from logging import *
+from .base import validatorBase
+from .validators import text
+from .logging import *
 
 #
 # skipHours element

--- a/src/feedvalidator/sse.py
+++ b/src/feedvalidator/sse.py
@@ -1,6 +1,6 @@
-from base import validatorBase
-from validators import *
-from logging import InvalidSseType, InvalidNSS, MissingElement, MissingByAndWhenAttrs
+from .base import validatorBase
+from .validators import *
+from .logging import InvalidSseType, InvalidNSS, MissingElement, MissingByAndWhenAttrs
 import re
 
 class Sharing(validatorBase):
@@ -8,20 +8,20 @@ class Sharing(validatorBase):
     return [ (None, u'expires'), (None, u'since'), (None, u'until') ]
 
   def prevalidate(self):
-    if self.attrs.has_key((None,'until')):
+    if (None,'until') in self.attrs:
       self.validate_required_attribute((None,'since'), rfc3339)
     else:
       self.validate_optional_attribute((None,'since'), rfc3339)
 
-    if self.attrs.has_key((None,'since')):
+    if (None,'since') in self.attrs:
       self.validate_required_attribute((None,'until'), rfc3339)
     else:
       self.validate_optional_attribute((None,'until'), rfc3339)
 
     self.validate_optional_attribute((None,'expires'), rfc3339)
 
-    if self.attrs.has_key((None,'since')):
-      if self.attrs.has_key((None,'until')):
+    if (None,'since') in self.attrs:
+      if (None,'until') in self.attrs:
         if self.attrs[(None,'since')]>self.attrs[(None,'until')]:
           self.log(SinceAfterUntil({}))
 
@@ -71,10 +71,10 @@ class History(validatorBase):
     self.validate_required_attribute((None,'sequence'), UINT31)
     self.validate_optional_attribute((None,'when'), rfc3339)
 
-    if self.attrs.has_key((None,'when')):
-      if not self.attrs.has_key((None,'by')):
+    if (None,'when') in self.attrs:
+      if (None,'by') not in self.attrs:
         self.log(MissingRecommendedAttribute({"attr":"by"}))
-    elif self.attrs.has_key((None,'by')):
+    elif (None,'by') in self.attrs:
       self.log(MissingRecommendedAttribute({"attr":"when"}))
     else:
       self.log(MissingByAndWhenAttrs({}))
@@ -90,8 +90,8 @@ class rfc2141_nss(text):
 
 class Conflicts(validatorBase):
   def do_entry(self):
-    from entry import entry
+    from .entry import entry
     return entry()
   def do_item(self):
-    from item import item
+    from .item import item
     return item()

--- a/src/feedvalidator/textInput.py
+++ b/src/feedvalidator/textInput.py
@@ -2,8 +2,8 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from validators import *
-from extension import extension_everywhere
+from .validators import *
+from .extension import extension_everywhere
 
 #
 # textInput element.

--- a/src/feedvalidator/timeoutsocket.py
+++ b/src/feedvalidator/timeoutsocket.py
@@ -188,7 +188,7 @@ class TimeoutSocket:
         errcode = 0
         try:
             self.connect(addr)
-        except Error, why:
+        except Error as why:
             errcode = why[0]
         return errcode
     # end connect_ex
@@ -208,7 +208,7 @@ class TimeoutSocket:
             sock.connect(addr)
             sock.setblocking(blocking)
             return
-        except Error, why:
+        except Error as why:
             # Set the socket's blocking mode back
             sock.setblocking(blocking)
 
@@ -254,7 +254,7 @@ class TimeoutSocket:
             timeoutnewsock = self.__class__(newsock, timeout)
             timeoutnewsock.setblocking(blocking)
             return (timeoutnewsock, addr)
-        except Error, why:
+        except Error as why:
             # Set the socket's blocking mode back
             sock.setblocking(blocking)
 

--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -2,10 +2,10 @@ __author__ = "Sam Ruby <http://intertwingly.net/> and Mark Pilgrim <http://divei
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
-from base import validatorBase
-from logging import *
+from .base import validatorBase
+from .logging import *
 import re, time, datetime
-from uri import canonicalForm, urljoin
+from .uri import canonicalForm, urljoin
 from rfc822 import AddressList, parsedate, parsedate_tz, mktime_tz
 
 rdfNS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -61,7 +61,7 @@ def any(self, name, qname, attrs):
   if self.getFeedType() != TYPE_RSS1:
     return eater()
   else:
-    from rdf import rdfExtension
+    from .rdf import rdfExtension
     return rdfExtension(qname)
 
 #
@@ -74,29 +74,29 @@ class eater(validatorBase):
   def characters(self, string):
     for c in string:
       if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
-        from validators import BadCharacters
+        from .validators import BadCharacters
         self.log(BadCharacters({"parent":self.parent.name, "element":self.name}))
 
   def startElementNS(self, name, qname, attrs):
     # RSS 2.0 arbitrary restriction on extensions
     feedtype=self.getFeedType()
     if (not qname) and feedtype and (feedtype==TYPE_RSS2) and self.name.find('_')>=0:
-       from logging import NotInANamespace
+       from .logging import NotInANamespace
        self.log(NotInANamespace({"parent":self.name, "element":name, "namespace":'""'}))
 
     # ensure element is "namespace well formed"
     if name.find(':') != -1:
-      from logging import MissingNamespace
+      from .logging import MissingNamespace
       self.log(MissingNamespace({"parent":self.name, "element":name}))
 
     # ensure all attribute namespaces are properly defined
     for (namespace,attr) in attrs.keys():
       if ':' in attr and not namespace:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":self.name, "element":attr}))
       for c in attrs.get((namespace,attr)):
         if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
-          from validators import BadCharacters
+          from .validators import BadCharacters
           self.log(BadCharacters({"parent":name, "element":attr}))
 
     # eat children
@@ -257,7 +257,7 @@ class HTMLValidator(HTMLParser):
       self.close()
       if self.valid:
         self.log(ValidHtml({"parent":self.element.parent.name, "element":self.element.name}))
-    except HTMLParseError, msg:
+    except HTMLParseError as msg:
       element = self.element
       offset = [element.line - element.dispatcher.locator.getLineNumber(),
                 - element.dispatcher.locator.getColumnNumber()]
@@ -357,17 +357,17 @@ class text(validatorBase):
         if self.attrs.get((u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')) != 'Literal':
           self.log(InvalidRDF({"message":"mixed content"}))
       if name=="div" and qname=="http://www.w3.org/1999/xhtml":
-        from content import diveater
+        from .content import diveater
         self.push(diveater(), name, attrs)
       else:
-        from rdf import rdfExtension
+        from .rdf import rdfExtension
         self.push(rdfExtension(qname), name, attrs)
     else:
-      from base import namespaces
+      from .base import namespaces
       ns = namespaces.get(qname, '')
 
       if name.find(':') != -1:
-        from logging import MissingNamespace
+        from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":self.name, "element":name}))
       else:
         self.log(UndefinedElement({"parent":self.name, "element":name}))
@@ -432,12 +432,12 @@ class addr_spec(text):
 # iso639 language code
 #
 def iso639_validate(log,value,element,parent):
-  import iso639codes
+  from . import iso639codes
   if '-' in value:
     lang, sublang = value.split('-', 1)
   else:
     lang = value
-  if not iso639codes.isoLang.has_key(unicode.lower(unicode(lang))):
+  if unicode.lower(unicode(lang)) not in iso639codes.isoLang:
     log(InvalidLanguage({"parent":parent, "element":element, "value":value}))
   else:
     log(ValidLanguage({"parent":parent, "element":element}))
@@ -495,7 +495,7 @@ class unbounded_iso8601(text):
       month=int(date[1])
       try:
         if len(date)>2: datetime.date(year,month,int(date[2]))
-      except ValueError, e:
+      except ValueError as e:
         return self.log(self.message({"parent":self.parent.name, "element":self.name, "value":str(e)}))
 
     if len(work) > 1:
@@ -686,7 +686,7 @@ class rfc822(text):
           if self.value.find(',')>0 and dow.lower() != self.value[:3].lower():
             self.log(IncorrectDOW({"parent":self.parent.name, "element":self.name, "value":self.value[:3]}))
             return
-      except ValueError, e:
+      except ValueError as e:
         self.log(InvalidRFC2822Date({"parent":self.parent.name, "element":self.name, "value":str(e)}))
         return
 

--- a/src/feedvalidator/xmlEncoding.py
+++ b/src/feedvalidator/xmlEncoding.py
@@ -11,8 +11,8 @@ __copyright__ = "Copyright (c) 2004 Joseph Walton"
 
 import codecs
 import re
-from logging import ObscureEncoding, NonstdEncoding
-import logging
+from .logging import ObscureEncoding, NonstdEncoding
+from . import logging
 
 class FailingCodec:
   def __init__(self, name):
@@ -248,7 +248,7 @@ def decode(mediaType, charset, bs, loggedEvents, fallback=None):
   dec = getdecoder(enc)
   try:
     return enc, dec(bs)[0]
-  except UnicodeError, ue:
+  except UnicodeError as ue:
     salvage = dec(bs, 'replace')[0]
     if 'start' in ue.__dict__:
       # XXX 'start' is in bytes, not characters. This is wrong for multibyte

--- a/src/feedvalidator/xrd.py
+++ b/src/feedvalidator/xrd.py
@@ -1,5 +1,5 @@
-from base import validatorBase
-from validators import *
+from .base import validatorBase
+from .validators import *
 
 class xrds(validatorBase):
   def do_xrd_XRD(self):

--- a/src/rdflib/syntax/parsers/RDFXMLHandler.py
+++ b/src/rdflib/syntax/parsers/RDFXMLHandler.py
@@ -145,8 +145,8 @@ class RDFXMLHandler(handler.ContentHandler):
                 ns_prefix[uri] = new_prefix
                 prefix_ns[new_prefix] = uri
         elif uri not in ns_prefix: # Only if we do not already have a
-				   # binding. So we do not clobber
-				   # things like rdf, rdfs
+                                   # binding. So we do not clobber
+                                   # things like rdf, rdfs
             ns_prefix[uri] = prefix
             prefix_ns[prefix] = uri
 

--- a/src/rdflib/syntax/parsers/RDFXMLHandler.py
+++ b/src/rdflib/syntax/parsers/RDFXMLHandler.py
@@ -315,7 +315,7 @@ class RDFXMLHandler(handler.ContentHandler):
                 predicate = absolutize(att)
                 try:
                     object = Literal(atts[att], language)
-                except Error, e:
+                except Error as e:
                     self.error(e.msg)
             elif att==TYPE: #S2
                 predicate = TYPE
@@ -329,7 +329,7 @@ class RDFXMLHandler(handler.ContentHandler):
                 predicate = absolutize(att)
                 try:
                     object = Literal(atts[att], language)
-                except Error, e:
+                except Error as e:
                     self.error(e.msg)
             self.store.add((subject, predicate, object))
 
@@ -449,13 +449,13 @@ class RDFXMLHandler(handler.ContentHandler):
         if current.object is None:
             try:
                 current.object = Literal(data, current.language, current.datatype)
-            except Error, e:
+            except Error as e:
                 self.error(e.msg)
         else:
             if isinstance(current.object, Literal):
                 try:
                     current.object += data
-                except Error, e:
+                except Error as e:
                     self.error(e.msg)
 
     def property_element_end(self, name, qname):

--- a/src/tests/testXmlEncoding.py
+++ b/src/tests/testXmlEncoding.py
@@ -217,7 +217,7 @@ def genInvalidXmlTestCases():
 #  try:
 #    yield('UTF-32', ['BOM', 'BE', 'declaration'],
 #      encoded('UTF-32', makeDecl('US-ASCII') + docText))
-#  except LookupError, e:
+#  except LookupError as e:
 #    print e
 #    someFailed = True
 

--- a/src/tests/testXmlEncoding.py
+++ b/src/tests/testXmlEncoding.py
@@ -25,7 +25,7 @@ class EncodingTestCase(unittest.TestCase):
   def testEncodingMatches(self):
     try:
       enc = xmlEncoding.detect(self.bytes)
-    except UnicodeError,u:
+    except UnicodeError as u:
       self.fail("'" + self.filename + "' should not cause an exception (" + str(u) + ")")
 
     self.assert_(enc, 'An encoding must be returned for all valid files ('
@@ -38,7 +38,7 @@ class EncodingTestCase(unittest.TestCase):
 
     try:
       encoding = xmlEncoding.detect(self.bytes, eventLog)
-    except UnicodeError,u:
+    except UnicodeError as u:
       self.fail("'" + self.filename + "' should not cause an exception (" + str(u) + ")")
 
     if encoding:
@@ -144,7 +144,7 @@ def genValidXmlTestCases():
 
     yield('ISO-10646-UCS-4', ['BOM', 'declaration', 'LE'],
       bom32LE + encoded('UCS-4LE', makeDecl('ISO-10646-UCS-4') + docText))
-  except LookupError, e:
+  except LookupError as e:
     print e
     someFailed = True
 
@@ -166,7 +166,7 @@ def genValidXmlTestCases():
   for enc in withDeclarations:
     try:
       yield(enc, ['declaration'], encoded(enc, makeDecl(enc) + docText))
-    except LookupError, e:
+    except LookupError as e:
       print e
       someFailed = True
 
@@ -185,7 +185,7 @@ def genValidXmlTestCases():
 
     yield('ISO-10646-UCS-4', ['declaration', 'LE'],
       bom32LE + encoded('UCS-4LE', makeDecl('ISO-10646-UCS-4') + docText))
-  except LookupError, e:
+  except LookupError as e:
     print e
     someFailed = True
 
@@ -202,7 +202,7 @@ def genValidXmlTestCases():
 
     yield('csucs4', ['alias', 'BE'],
       encoded('csucs4', makeDecl('csucs4') + docText))
-  except LookupError, e:
+  except LookupError as e:
     print e
     someFailed = True
 
@@ -241,7 +241,7 @@ def genInvalidXmlTestCases():
     # UTF-32, with a BOM, and a declaration with no encoding
     yield('UTF-32', ['BOM', 'BE', 'noenc'],
       bom32BE + encoded('UTF-32BE', makeDecl() + docText))
-  except LookupError, e:
+  except LookupError as e:
     print e
     someFailed = True
 
@@ -282,7 +282,7 @@ def buildTestSuite():
       t.filename = name
       t.bytes = x
       suite.addTest(t)
-    except LookupError,e:
+    except LookupError as e:
       print "Skipping " + name + ": " + str(e)
       skippedNames.append(name)
   return suite

--- a/src/validtest.py
+++ b/src/validtest.py
@@ -23,12 +23,12 @@ class TestCase(unittest.TestCase):
     """Fail if there are no instances of theClass in theList with given params"""
     self.failIfNoMessage(theList)
 
-    failure=(msg or 'no %s instances in %s' % (theClass.__name__, `theList`))
+    failure=(msg or 'no %s instances in %s' % (theClass.__name__, repr(theList)))
     for item in theList:
       if issubclass(item.__class__, theClass):
         if not params: return
         for k, v in params.items():
-          if str(item.params[k]) <> v:
+          if str(item.params[k]) != v:
             failure=("%s.%s value was %s, expected %s" %
                (theClass.__name__, k, item.params[k], v))
             break

--- a/time.cgi
+++ b/time.cgi
@@ -1,5 +1,5 @@
 #!/usr/bin/python
-print "Content-type: text/plain\r\n\r\n", 
+print "Content-type: text/plain\r\n\r\n",
 
 import rfc822
 import time
@@ -7,4 +7,3 @@ import time
 print "Current time:\n"
 print "  RFC 2822: " + rfc822.formatdate()
 print "  RFC 3339: " + time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
-


### PR DESCRIPTION
Use 2to3 to make some syntax changes for Python 3 that are also accepted
by Python 2.

- Use except ... as
- Use 'in' instead of has_key
- Use repr instead of backticks
- Use '.' for relative imports
- Replace '<>' with '!='