### PR TITLE
Clean up the markup

### DIFF
--- a/about.html
+++ b/about.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>About the Feed Validator</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "css/common.css";
+<style media="screen">@import "css/common.css";
 @import "css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 
@@ -97,12 +96,12 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
 <address>Copyright © 2002-6
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/alt-banners.html
+++ b/alt-banners.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator: alternate banners</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "css/common.css";
+<style media="screen">@import "css/common.css";
 @import "css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 
@@ -23,28 +22,28 @@
 <p>If the default "valid RSS" banner is not your style, you can use any of these, or anything else you design, or nothing at all.  The fact that you care enough to validate your feed is the important part; how you advertise it is up to you.</p>
 
 <p style="line-height:300%">
-<img alt="Brockman Bulger's entry" title="by Brockman Bulger" src="/images/valid-rss-bbulger.png" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #2" title="by Dylan Parker" src="/images/valid-rss-dylan2.gif" width="88" height="31" /> &nbsp; 
-<img alt="Neil Lee's entry with white background" title="by Neil Lee" src="/images/valid-rss-white-neil.gif" width="88" height="31" /> &nbsp; 
-<img alt="Dougal Campbell's entry with white background" title="by Dougal Campbell" src="/images/valid-rss-white-dougal.gif" width="88" height="31" /> &nbsp; 
-<img alt="Robert Guertin's entry" title="by Robert Guertin" src="/images/valid-rss-robert.jpg" width="88" height="31" /> &nbsp; 
-<img alt="Jon Wiley's entry" title="by Jon Wiley" src="/images/valid-rss-jon-wiley.gif" width="88" height="31" /> &nbsp; 
-<img alt="Jonathon Delacour's entry" title="by Jonathon Delacour" src="/images/valid-rss-jonathan.gif" width="88" height="31" /> &nbsp; 
-<img alt="Lee O'Mara's entry" title="by Lee O'Mara" src="/images/valid-rss-lee.gif" width="88" height="31" /> &nbsp; 
-<img alt="Aaron Swartz's entry" title="by Aaron Swartz" src="/images/valid-rss-aaron.png" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #1" title="by Dylan Parker" src="/images/valid-rss-dylan1.gif" width="88" height="31" /> &nbsp; 
-<img alt="Shelley Powers' entry" title="by Shelley Powers" src="/images/valid-rss-shelley.gif" width="88" height="31" /> &nbsp; 
-<img alt="Walt Dickinson's entry with orange background" title="by Walt Dickinson" src="/images/valid-rss-orange-walt.gif" width="88" height="31" /> &nbsp; 
-<img alt="Walt Dickinson's entry with red background" title="by Walt Dickinson" src="/images/valid-rss-red-walt.gif" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #4" title="by Dylan Parker" src="/images/valid-rss-dylan4.gif" width="88" height="31" /> &nbsp; 
-<img alt="Walk Dickinson's entry with grey background" title="by Walt Dickinson" src="/images/valid-rss-grey-walt.gif" width="88" height="31" /> &nbsp; 
-<img alt="Neil Lee's entry with maroon background" title="by Neil Lee" src="/images/valid-rss-neil.gif" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #3" title="by Dylan Parker" src="/images/valid-rss-dylan3.gif" width="88" height="31" /> &nbsp; 
-<img alt="Martin Murtonen's entry" title="by Martin Murtonen" src="/images/valid-rss-martin.gif" /> &nbsp; 
-<img alt="Dougal Campbell's entry with black background" title="by Dougal Campbell" src="/images/valid-rss-black-dougal.gif" width="88" height="31" /> &nbsp; 
-<img alt="Nicholas Avenell's entry" title="by Nicholas Avenell" src="/images/valid-rss-nicholas.png" width="88" height="31" /> &nbsp; 
-<img alt="Aaron Swartz's entry, based on a design by antipixel.com" title="by Aaron Swartz (in the style of antipixel.com)" src="/images/valid-rss-antipixel.png" width="80" height="15" /> &nbsp; 
-<img alt="Jack Greenwood's entry" title="by Jack Greenwood" src="/images/kiss-my-rss.gif" width="88" height="31" /> &nbsp; 
+<img alt="Brockman Bulger's entry" title="by Brockman Bulger" src="/images/valid-rss-bbulger.png" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #2" title="by Dylan Parker" src="/images/valid-rss-dylan2.gif" width="88" height="31" /> &nbsp;
+<img alt="Neil Lee's entry with white background" title="by Neil Lee" src="/images/valid-rss-white-neil.gif" width="88" height="31" /> &nbsp;
+<img alt="Dougal Campbell's entry with white background" title="by Dougal Campbell" src="/images/valid-rss-white-dougal.gif" width="88" height="31" /> &nbsp;
+<img alt="Robert Guertin's entry" title="by Robert Guertin" src="/images/valid-rss-robert.jpg" width="88" height="31" /> &nbsp;
+<img alt="Jon Wiley's entry" title="by Jon Wiley" src="/images/valid-rss-jon-wiley.gif" width="88" height="31" /> &nbsp;
+<img alt="Jonathon Delacour's entry" title="by Jonathon Delacour" src="/images/valid-rss-jonathan.gif" width="88" height="31" /> &nbsp;
+<img alt="Lee O'Mara's entry" title="by Lee O'Mara" src="/images/valid-rss-lee.gif" width="88" height="31" /> &nbsp;
+<img alt="Aaron Swartz's entry" title="by Aaron Swartz" src="/images/valid-rss-aaron.png" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #1" title="by Dylan Parker" src="/images/valid-rss-dylan1.gif" width="88" height="31" /> &nbsp;
+<img alt="Shelley Powers' entry" title="by Shelley Powers" src="/images/valid-rss-shelley.gif" width="88" height="31" /> &nbsp;
+<img alt="Walt Dickinson's entry with orange background" title="by Walt Dickinson" src="/images/valid-rss-orange-walt.gif" width="88" height="31" /> &nbsp;
+<img alt="Walt Dickinson's entry with red background" title="by Walt Dickinson" src="/images/valid-rss-red-walt.gif" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #4" title="by Dylan Parker" src="/images/valid-rss-dylan4.gif" width="88" height="31" /> &nbsp;
+<img alt="Walk Dickinson's entry with grey background" title="by Walt Dickinson" src="/images/valid-rss-grey-walt.gif" width="88" height="31" /> &nbsp;
+<img alt="Neil Lee's entry with maroon background" title="by Neil Lee" src="/images/valid-rss-neil.gif" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #3" title="by Dylan Parker" src="/images/valid-rss-dylan3.gif" width="88" height="31" /> &nbsp;
+<img alt="Martin Murtonen's entry" title="by Martin Murtonen" src="/images/valid-rss-martin.gif" /> &nbsp;
+<img alt="Dougal Campbell's entry with black background" title="by Dougal Campbell" src="/images/valid-rss-black-dougal.gif" width="88" height="31" /> &nbsp;
+<img alt="Nicholas Avenell's entry" title="by Nicholas Avenell" src="/images/valid-rss-nicholas.png" width="88" height="31" /> &nbsp;
+<img alt="Aaron Swartz's entry, based on a design by antipixel.com" title="by Aaron Swartz (in the style of antipixel.com)" src="/images/valid-rss-antipixel.png" width="80" height="15" /> &nbsp;
+<img alt="Jack Greenwood's entry" title="by Jack Greenwood" src="/images/kiss-my-rss.gif" width="88" height="31" /> &nbsp;
 </p>
 
 <p>Designers who wish to have their "valid RSS" banner listed here should email it to <a href="mailto:feed-validator@diveintomark.org">feed-validator@diveintomark.org</a>.</p>
@@ -72,7 +71,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/docs-xml/docs-index-header.html
+++ b/docs-xml/docs-index-header.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Documentation</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../css/common.css";
+<style media="screen">@import "../css/common.css";
 @import "../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 

--- a/docs-xml/template.html
+++ b/docs-xml/template.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title></title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/about.tmpl
+++ b/docs/about.tmpl
@@ -1,7 +1,7 @@
 <$MTInclude module="doctype"$>
 <head>
+<meta charset="utf-8">
 <title>About the Feed Validator</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <$MTInclude module="css"$>
 </head>
 <body>

--- a/docs/atom.html
+++ b/docs/atom.html
@@ -1,16 +1,15 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Introduction to Atom</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">
+<style media="screen">
   @import "../css/common.css";
   @import "../css/documentation.css";
   #main h2 { font-size: 200%; }
   pre { padding-left: 3em; }
 </style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 
@@ -61,9 +60,9 @@
 <p>Atom is the name of an XML-based Web content and metadata syndication format, and an application-level protocol for publishing and editing Web resources belonging to periodically updated websites.</p>
 <p>All Atom feeds must be well-formed <a href="http://www.w3.org/TR/REC-xml">XML</a> documents, and are identified with the <code>application/atom+xml</code> media type.</p>
 <h3>About this document<a id="aboutThisDocument" name="aboutThisDocument"> </a></h3>
-<p>This document focuses on 
+<p>This document focuses on
 <a href="rfc4287.html">The Atom Syndication Format</a>
-produced by the 
+produced by the
 <a href="http://www.ietf.org/" title="Internet Engineering Task Force">IETF</a>
 <a href="http://www.ietf.org/html.charters/atompub-charter.html">AtomPub Working Group</a>.  In the event that this document differs from the Internet Draft, the Internet Draft is to be considered authoritative.</p>
 <p>General considerations:</p>
@@ -148,7 +147,7 @@ Atom makes a number of additional requirements and recommendations for feed elem
 <tr>
 <td valign="top">author</td>
 <td valign="top">Names one author of the feed.  A feed may have multiple
-<code>author</code> elements.  A feed must contain at least one 
+<code>author</code> elements.  A feed must contain at least one
 <code>author</code> element unless <b>all</b> of the <code>entry</code>
 elements contain at least one <code>author</code> element.  More
 info <a href="#person">here</a>.
@@ -277,7 +276,7 @@ Atom makes a number of additional requirements and recommendations for entry ele
 <tr>
 <td valign="top">author</td>
 <td valign="top">Names one author of the entry.  An entry
-may have multiple authors.  An entry must contain at least one 
+may have multiple authors.  An entry must contain at least one
 <code>author</code> element unless there is an <code>author</code> element
 in the enclosing <code>feed</code>, or there is an <code>author</code> element
 in the enclosed <code>source</code> element.
@@ -362,7 +361,7 @@ entry is a copy.
 <h3 id="category">Category<a name="category"> </a></h3>
 <p><code>&lt;category&gt;</code> has one required attribute, <code>term</code>, and two optional attributes, <code>scheme</code> and <code>label</code>.</p>
 <p><code>term</code> identifies the category</p>
-<p><code>scheme</code> identifies the categorization scheme via a 
+<p><code>scheme</code> identifies the categorization scheme via a
 <abbr title="Universal Resource Identifier">URI</abbr>.
 </p>
 <p><code>label</code> provides a human-readable label for display</p>
@@ -448,7 +447,7 @@ entry is a copy.
         <img class="borderBL" src="../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 </div><!-- .main -->
 

--- a/docs/banners.tmpl
+++ b/docs/banners.tmpl
@@ -1,7 +1,7 @@
 <$MTInclude module="doctype"$>
 <head>
+<meta charset="utf-8">
 <title>Feed Validator: alternate banners</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <$MTInclude module="css"$>
 </head>
 <body>
@@ -19,28 +19,28 @@
 <p>If the default "valid RSS" banner is not your style, you can use any of these, or anything else you design, or nothing at all.  The fact that you care enough to validate your feed is the important part; how you advertise it is up to you.</p>
 
 <p style="line-height:300%">
-<img alt="Brockman Bulger's entry" title="by Brockman Bulger" src="/images/valid-rss-bbulger.png" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #2" title="by Dylan Parker" src="/images/valid-rss-dylan2.gif" width="88" height="31" /> &nbsp; 
-<img alt="Neil Lee's entry with white background" title="by Neil Lee" src="/images/valid-rss-white-neil.gif" width="88" height="31" /> &nbsp; 
-<img alt="Dougal Campbell's entry with white background" title="by Dougal Campbell" src="/images/valid-rss-white-dougal.gif" width="88" height="31" /> &nbsp; 
-<img alt="Robert Guertin's entry" title="by Robert Guertin" src="/images/valid-rss-robert.jpg" width="88" height="31" /> &nbsp; 
-<img alt="Jon Wiley's entry" title="by Jon Wiley" src="/images/valid-rss-jon-wiley.gif" width="88" height="31" /> &nbsp; 
-<img alt="Jonathon Delacour's entry" title="by Jonathon Delacour" src="/images/valid-rss-jonathan.gif" width="88" height="31" /> &nbsp; 
-<img alt="Lee O'Mara's entry" title="by Lee O'Mara" src="/images/valid-rss-lee.gif" width="88" height="31" /> &nbsp; 
-<img alt="Aaron Swartz's entry" title="by Aaron Swartz" src="/images/valid-rss-aaron.png" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #1" title="by Dylan Parker" src="/images/valid-rss-dylan1.gif" width="88" height="31" /> &nbsp; 
-<img alt="Shelley Powers' entry" title="by Shelley Powers" src="/images/valid-rss-shelley.gif" width="88" height="31" /> &nbsp; 
-<img alt="Walt Dickinson's entry with orange background" title="by Walt Dickinson" src="/images/valid-rss-orange-walt.gif" width="88" height="31" /> &nbsp; 
-<img alt="Walt Dickinson's entry with red background" title="by Walt Dickinson" src="/images/valid-rss-red-walt.gif" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #4" title="by Dylan Parker" src="/images/valid-rss-dylan4.gif" width="88" height="31" /> &nbsp; 
-<img alt="Walk Dickinson's entry with grey background" title="by Walt Dickinson" src="/images/valid-rss-grey-walt.gif" width="88" height="31" /> &nbsp; 
-<img alt="Neil Lee's entry with maroon background" title="by Neil Lee" src="/images/valid-rss-neil.gif" width="88" height="31" /> &nbsp; 
-<img alt="Dylan Parker's entry #3" title="by Dylan Parker" src="/images/valid-rss-dylan3.gif" width="88" height="31" /> &nbsp; 
-<img alt="Martin Murtonen's entry" title="by Martin Murtonen" src="/images/valid-rss-martin.gif" /> &nbsp; 
-<img alt="Dougal Campbell's entry with black background" title="by Dougal Campbell" src="/images/valid-rss-black-dougal.gif" width="88" height="31" /> &nbsp; 
-<img alt="Nicholas Avenell's entry" title="by Nicholas Avenell" src="/images/valid-rss-nicholas.png" width="88" height="31" /> &nbsp; 
-<img alt="Aaron Swartz's entry, based on a design by antipixel.com" title="by Aaron Swartz (in the style of antipixel.com)" src="/images/valid-rss-antipixel.png" width="80" height="15" /> &nbsp; 
-<img alt="Jack Greenwood's entry" title="by Jack Greenwood" src="/images/kiss-my-rss.gif" width="88" height="31" /> &nbsp; 
+<img alt="Brockman Bulger's entry" title="by Brockman Bulger" src="/images/valid-rss-bbulger.png" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #2" title="by Dylan Parker" src="/images/valid-rss-dylan2.gif" width="88" height="31" /> &nbsp;
+<img alt="Neil Lee's entry with white background" title="by Neil Lee" src="/images/valid-rss-white-neil.gif" width="88" height="31" /> &nbsp;
+<img alt="Dougal Campbell's entry with white background" title="by Dougal Campbell" src="/images/valid-rss-white-dougal.gif" width="88" height="31" /> &nbsp;
+<img alt="Robert Guertin's entry" title="by Robert Guertin" src="/images/valid-rss-robert.jpg" width="88" height="31" /> &nbsp;
+<img alt="Jon Wiley's entry" title="by Jon Wiley" src="/images/valid-rss-jon-wiley.gif" width="88" height="31" /> &nbsp;
+<img alt="Jonathon Delacour's entry" title="by Jonathon Delacour" src="/images/valid-rss-jonathan.gif" width="88" height="31" /> &nbsp;
+<img alt="Lee O'Mara's entry" title="by Lee O'Mara" src="/images/valid-rss-lee.gif" width="88" height="31" /> &nbsp;
+<img alt="Aaron Swartz's entry" title="by Aaron Swartz" src="/images/valid-rss-aaron.png" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #1" title="by Dylan Parker" src="/images/valid-rss-dylan1.gif" width="88" height="31" /> &nbsp;
+<img alt="Shelley Powers' entry" title="by Shelley Powers" src="/images/valid-rss-shelley.gif" width="88" height="31" /> &nbsp;
+<img alt="Walt Dickinson's entry with orange background" title="by Walt Dickinson" src="/images/valid-rss-orange-walt.gif" width="88" height="31" /> &nbsp;
+<img alt="Walt Dickinson's entry with red background" title="by Walt Dickinson" src="/images/valid-rss-red-walt.gif" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #4" title="by Dylan Parker" src="/images/valid-rss-dylan4.gif" width="88" height="31" /> &nbsp;
+<img alt="Walk Dickinson's entry with grey background" title="by Walt Dickinson" src="/images/valid-rss-grey-walt.gif" width="88" height="31" /> &nbsp;
+<img alt="Neil Lee's entry with maroon background" title="by Neil Lee" src="/images/valid-rss-neil.gif" width="88" height="31" /> &nbsp;
+<img alt="Dylan Parker's entry #3" title="by Dylan Parker" src="/images/valid-rss-dylan3.gif" width="88" height="31" /> &nbsp;
+<img alt="Martin Murtonen's entry" title="by Martin Murtonen" src="/images/valid-rss-martin.gif" /> &nbsp;
+<img alt="Dougal Campbell's entry with black background" title="by Dougal Campbell" src="/images/valid-rss-black-dougal.gif" width="88" height="31" /> &nbsp;
+<img alt="Nicholas Avenell's entry" title="by Nicholas Avenell" src="/images/valid-rss-nicholas.png" width="88" height="31" /> &nbsp;
+<img alt="Aaron Swartz's entry, based on a design by antipixel.com" title="by Aaron Swartz (in the style of antipixel.com)" src="/images/valid-rss-antipixel.png" width="80" height="15" /> &nbsp;
+<img alt="Jack Greenwood's entry" title="by Jack Greenwood" src="/images/kiss-my-rss.gif" width="88" height="31" /> &nbsp;
 </p>
 
 <p>Designers who wish to have their "valid RSS" banner listed here should email it to <a href="mailto:feed-validator@diveintomark.org">feed-validator@diveintomark.org</a>.</p>

--- a/docs/error/AtomLinkNotEmpty.html
+++ b/docs/error/AtomLinkNotEmpty.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo should not have text (all data is in attributes)</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/BadXmlVersion.html
+++ b/docs/error/BadXmlVersion.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feeds must specify XML Version 1.0</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/ConflictingCatAttr.html
+++ b/docs/error/ConflictingCatAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Categories can't have both href and foo attributes</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/ConflictingCatChildren.html
+++ b/docs/error/ConflictingCatChildren.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Categories can't have both href attributes and children</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/ContainsSystemEntity.html
+++ b/docs/error/ContainsSystemEntity.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feeds must not contain SYSTEM entities</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/CurrentNotSelfInCompleteFeed.html
+++ b/docs/error/CurrentNotSelfInCompleteFeed.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Current not self in complete feed</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/DeprecatedDTD.html
+++ b/docs/error/DeprecatedDTD.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>The use of this DTD has been deprecated by Netscape</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/DuplicateAtomLink.html
+++ b/docs/error/DuplicateAtomLink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Duplicate alternate links with the same type and hreflang</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/DuplicateElement.html
+++ b/docs/error/DuplicateElement.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo contains more than one bar</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/DuplicateIds.html
+++ b/docs/error/DuplicateIds.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>All entries have the same id</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/DuplicateValue.html
+++ b/docs/error/DuplicateValue.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element values must not be duplicated within a feed</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/EightDaysAWeek.html
+++ b/docs/error/EightDaysAWeek.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>skipDays can not contain more than 7 day elements</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/FeedRelInCompleteFeed.html
+++ b/docs/error/FeedRelInCompleteFeed.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo link relation found in complete feed</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/HttpError.html
+++ b/docs/error/HttpError.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>HTTP Error</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/HttpErrorWithPossibleFeed.html
+++ b/docs/error/HttpErrorWithPossibleFeed.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>HTTP error with content that looks like a feed</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/HttpProtocolError.html
+++ b/docs/error/HttpProtocolError.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>HTTP Protocol Error</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/IOError.html
+++ b/docs/error/IOError.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>IO Error</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/IncorrectDOW.html
+++ b/docs/error/IncorrectDOW.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Incorrect day of week: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/IntegerOverflow.html
+++ b/docs/error/IntegerOverflow.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>attribute value too large</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidAccessRestrictionRel.html
+++ b/docs/error/InvalidAccessRestrictionRel.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for access:restriction: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidAddrSpec.html
+++ b/docs/error/InvalidAddrSpec.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an email address</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidAlphanum.html
+++ b/docs/error/InvalidAlphanum.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be alphanumeric</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidAltitudeMode.html
+++ b/docs/error/InvalidAltitudeMode.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid altitudeMode</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidAngle.html
+++ b/docs/error/InvalidAngle.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be between -360 and 360</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidBooleanAttribute.html
+++ b/docs/error/InvalidBooleanAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be 'true' or 'false'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidColor.html
+++ b/docs/error/InvalidColor.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Not a valid color</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidColorMode.html
+++ b/docs/error/InvalidColorMode.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid colorMode.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidCommaSeparatedIntegers.html
+++ b/docs/error/InvalidCommaSeparatedIntegers.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be comma-separated integers</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -30,7 +27,7 @@
 </div>
 <h2>Solution</h2>
 <div class="docbody">
-<p>Convert the value to a list of comma-separated integers. Examples 
+<p>Convert the value to a list of comma-separated integers. Examples
 of valid comma-separated integers:</p>
 <ul>
 <li><samp>1</samp></li>

--- a/docs/error/InvalidContact.html
+++ b/docs/error/InvalidContact.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid email address</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidContentMode.html
+++ b/docs/error/InvalidContentMode.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not a valid mode</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidCoord.html
+++ b/docs/error/InvalidCoord.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Coordinate</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidCoordList.html
+++ b/docs/error/InvalidCoordList.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Coordinate</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidCountryCode.html
+++ b/docs/error/InvalidCountryCode.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid counry code: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidCreditRole.html
+++ b/docs/error/InvalidCreditRole.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Credit Role</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidCurrencyUnit.html
+++ b/docs/error/InvalidCurrencyUnit.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:currency: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidDay.html
+++ b/docs/error/InvalidDay.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, or Sunday</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidDoctype.html
+++ b/docs/error/InvalidDoctype.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>This feed contains conflicting DOCTYPE and version information</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidDuration.html
+++ b/docs/error/InvalidDuration.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid duration: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidEncoding.html
+++ b/docs/error/InvalidEncoding.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid character encoding: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidExpansionState.html
+++ b/docs/error/InvalidExpansionState.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title><expansionState> is a comma-separated list of line numbers.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidFloat.html
+++ b/docs/error/InvalidFloat.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for foo: "bar"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidFloatUnit.html
+++ b/docs/error/InvalidFloatUnit.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for foo: "bar"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidFormComponentName.html
+++ b/docs/error/InvalidFormComponentName.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid form component name</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidFullLink.html
+++ b/docs/error/InvalidFullLink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element must be a full URI</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidFullLocation.html
+++ b/docs/error/InvalidFullLocation.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:location: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidGender.html
+++ b/docs/error/InvalidGender.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:gender: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidHeight.html
+++ b/docs/error/InvalidHeight.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be between 1 and 400</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidHour.html
+++ b/docs/error/InvalidHour.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be between an integer 0 and 23</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidHttpGUID.html
+++ b/docs/error/InvalidHttpGUID.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>guid must be a full URL, unless isPermaLink attribute is false</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidIRI.html
+++ b/docs/error/InvalidIRI.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be a valid IRI</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidISO8601Date.html
+++ b/docs/error/InvalidISO8601Date.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an ISO-8601 date</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidISO8601DateTime.html
+++ b/docs/error/InvalidISO8601DateTime.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an ISO-8601 date-time</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidIntUnit.html
+++ b/docs/error/InvalidIntUnit.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for foo: "bar"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidInteger.html
+++ b/docs/error/InvalidInteger.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an integer</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidIntegerAttribute.html
+++ b/docs/error/InvalidIntegerAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be a positive integer</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidItemIconState.html
+++ b/docs/error/InvalidItemIconState.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid state for Icon</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidItunesCategory.html
+++ b/docs/error/InvalidItunesCategory.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not one of the predefined iTunes categories or sub-categories</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -27,7 +24,7 @@
 
 <div class="docbody">
 <p>itunes:category can only be populated using iTunes specific catgories or
-sub-categories, as listed in the 
+sub-categories, as listed in the
 <a href="http://www.apple.com/itunes/podcasts/techspecs.html#_Toc526931698">specification</a>.</p>
 </div>
 <h2>Solution</h2>

--- a/docs/error/InvalidKmlCoordList.html
+++ b/docs/error/InvalidKmlCoordList.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid coordinate list. Make sure that coordinates are of the form longitude,latitude or longitude,latitude,altitude and seperated by a single space. It is also a good idea to avoid line breaks or other extraneous white space</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidKmlLatitude.html
+++ b/docs/error/InvalidKmlLatitude.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid latitude found within coordinates. Latitudes have to be between -90 and 90.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidKmlLongitude.html
+++ b/docs/error/InvalidKmlLongitude.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid longitude found within coordinates. Longitudes have to be between -180 and 180.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidKmlUnits.html
+++ b/docs/error/InvalidKmlUnits.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid units.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLabel.html
+++ b/docs/error/InvalidLabel.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:label: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLanguage.html
+++ b/docs/error/InvalidLanguage.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an ISO-639 language code</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLatitude.html
+++ b/docs/error/InvalidLatitude.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be between -90 and 90</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLink.html
+++ b/docs/error/InvalidLink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be a valid URI</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidListItemType.html
+++ b/docs/error/InvalidListItemType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid list item type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLocalParameter.html
+++ b/docs/error/InvalidLocalParameter.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid local parameter name: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLocalRole.html
+++ b/docs/error/InvalidLocalRole.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid local role: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -31,7 +28,7 @@
 <dd>   Represents the search query that can be performed to retrieve the same set of search results.
 </dd>
 <dt><code>"example"</code></dt>
-<dd>   Represents a search query that can be performed to demonstrate the search engine. 
+<dd>   Represents a search query that can be performed to demonstrate the search engine.
 </dd>
 <dt><code>"related"</code></dt>
 <dd>   Represents a search query that can be performed to retrieve similar but different search results.

--- a/docs/error/InvalidLocation.html
+++ b/docs/error/InvalidLocation.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for foo: "bar"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidLongitude.html
+++ b/docs/error/InvalidLongitude.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be between -180 and 180</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMIMEAttribute.html
+++ b/docs/error/InvalidMIMEAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be a valid MIME type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMIMEType.html
+++ b/docs/error/InvalidMIMEType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not a valid MIME type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMaritalStatus.html
+++ b/docs/error/InvalidMaritalStatus.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:marital_status: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaExpression.html
+++ b/docs/error/InvalidMediaExpression.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid content expression: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaHash.html
+++ b/docs/error/InvalidMediaHash.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Media Hash</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaMedium.html
+++ b/docs/error/InvalidMediaMedium.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid content medium: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaRating.html
+++ b/docs/error/InvalidMediaRating.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Media Rating</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -54,7 +51,7 @@ one of the values listed below.</li>
 <samp>tv-y7-fv</samp></li>
 
 <li><b><samp>urn:icra</samp></b>: Internet Content Rating Association labels
-consist of a <a href="http://www.icra.org/decode/">set of codes</a> 
+consist of a <a href="http://www.icra.org/decode/">set of codes</a>
 (please select from the values defined in 2005) formatted per the following
 sample: <samp>r (cz 1 lz 1 mz 1 oz 1 vz 1)</samp></li>
 

--- a/docs/error/InvalidMediaRestriction.html
+++ b/docs/error/InvalidMediaRestriction.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>media:restriction must be 'all' or 'none'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaRestrictionRel.html
+++ b/docs/error/InvalidMediaRestrictionRel.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>relationship must be 'allow' or 'disallow'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaRestrictionType.html
+++ b/docs/error/InvalidMediaRestrictionType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>type must be 'country' or 'uri'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMediaTextType.html
+++ b/docs/error/InvalidMediaTextType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>type attribute must be "plain" or "html"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMetaContent.html
+++ b/docs/error/InvalidMetaContent.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for content: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidMetaName.html
+++ b/docs/error/InvalidMetaName.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for name: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidNPTTime.html
+++ b/docs/error/InvalidNPTTime.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an NPT-time</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidNSS.html
+++ b/docs/error/InvalidNSS.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Namespace Specific String: attribute</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidNamespace.html
+++ b/docs/error/InvalidNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is in an invalid namespace</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidNonNegativeInteger.html
+++ b/docs/error/InvalidNonNegativeInteger.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be a non-negative integer</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidOPMLVersion.html
+++ b/docs/error/InvalidOPMLVersion.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>The "version" attribute for the opml element must be 1.0, 1.1 or 2.0.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidPaymentMethod.html
+++ b/docs/error/InvalidPaymentMethod.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:payment_accepted: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidPercentage.html
+++ b/docs/error/InvalidPercentage.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be a percentage</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidPermalink.html
+++ b/docs/error/InvalidPermalink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>guid must be a full URL, unless isPermaLink attribute is false</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidPositiveInteger.html
+++ b/docs/error/InvalidPositiveInteger.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be a positive integer</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidPriceType.html
+++ b/docs/error/InvalidPriceType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:price_type: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidRDF.html
+++ b/docs/error/InvalidRDF.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>RDF Parsing Error</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidRFC2822Date.html
+++ b/docs/error/InvalidRFC2822Date.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element must be an RFC-822 date-time</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidRFC3339Date.html
+++ b/docs/error/InvalidRFC3339Date.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an RFC 3339 date-time</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidRSSVersion.html
+++ b/docs/error/InvalidRSSVersion.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid RSS Version: x.y</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidRatingType.html
+++ b/docs/error/InvalidRatingType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:rating: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidRefreshMode.html
+++ b/docs/error/InvalidRefreshMode.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid refreshMode</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidReviewerType.html
+++ b/docs/error/InvalidReviewerType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:reviewer_type: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidSalaryType.html
+++ b/docs/error/InvalidSalaryType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:salary_type: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidSchemaFieldType.html
+++ b/docs/error/InvalidSchemaFieldType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid Schema field type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidServiceType.html
+++ b/docs/error/InvalidServiceType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:service: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidSseType.html
+++ b/docs/error/InvalidSseType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for sx:related type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidStyleState.html
+++ b/docs/error/InvalidStyleState.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid key for StyleMap.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidSyndicationRight.html
+++ b/docs/error/InvalidSyndicationRight.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for SyndicationRight: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidTAG.html
+++ b/docs/error/InvalidTAG.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not a valid TAG</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidTextType.html
+++ b/docs/error/InvalidTextType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>type attribute must be "text", "html", or "xhtml"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidTrueFalse.html
+++ b/docs/error/InvalidTrueFalse.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be 'true' or 'false'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidURI.html
+++ b/docs/error/InvalidURI.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not a valid URI</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidURIAttribute.html
+++ b/docs/error/InvalidURIAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be a valid URI</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidURLAttribute.html
+++ b/docs/error/InvalidURLAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be a full URL</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidURN.html
+++ b/docs/error/InvalidURN.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not a valid URN</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidUUID.html
+++ b/docs/error/InvalidUUID.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is not a valid UUID</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidUpdatePeriod.html
+++ b/docs/error/InvalidUpdatePeriod.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be hourly, daily, weekly, monthly, or yearly</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidUriChar.html
+++ b/docs/error/InvalidUriChar.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid character in a URI: c</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidValue.html
+++ b/docs/error/InvalidValue.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for foo: "bar"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidViewRefreshMode.html
+++ b/docs/error/InvalidViewRefreshMode.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid viewRefreshMode.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidW3CDTFDate.html
+++ b/docs/error/InvalidW3CDTFDate.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be an W3CDTF date</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidWidth.html
+++ b/docs/error/InvalidWidth.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must be between 1 and 144</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidYear.html
+++ b/docs/error/InvalidYear.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value for g:year: "foo"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidYesNo.html
+++ b/docs/error/InvalidYesNo.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be 'yes' or 'no'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidYesNoClean.html
+++ b/docs/error/InvalidYesNoClean.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar must be 'yes', 'no', or 'clean'</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/InvalidZeroOne.html
+++ b/docs/error/InvalidZeroOne.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid value. Should be 0 or 1.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/ItemMustContainTitleOrDescription.html
+++ b/docs/error/ItemMustContainTitleOrDescription.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>item must contain either title or description</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/LinkPastEnd.html
+++ b/docs/error/LinkPastEnd.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Link past end of list</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MediaGroupWithoutAlternatives.html
+++ b/docs/error/MediaGroupWithoutAlternatives.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>media:group must have multiple media:content children</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MediaRssNamespace.html
+++ b/docs/error/MediaRssNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing trailing slash in mediaRSS namespace</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MisplacedMetadata.html
+++ b/docs/error/MisplacedMetadata.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must appear before all entries</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingAttribute.html
+++ b/docs/error/MissingAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing element attribute: attribute-name</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingByAndWhenAttrs.html
+++ b/docs/error/MissingByAndWhenAttrs.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing by and when attributes</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingContentOrAlternate.html
+++ b/docs/error/MissingContentOrAlternate.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing content or alternate link</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingDescription.html
+++ b/docs/error/MissingDescription.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing foo element: description</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingElement.html
+++ b/docs/error/MissingElement.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing parent element: child</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingHref.html
+++ b/docs/error/MissingHref.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo must have an href attribute</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingLink.html
+++ b/docs/error/MissingLink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing foo element: link</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingNamespace.html
+++ b/docs/error/MissingNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing namespace for foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingSummary.html
+++ b/docs/error/MissingSummary.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing Summary</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingTitle.html
+++ b/docs/error/MissingTitle.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing foo element: title</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/MissingXhtmlDiv.html
+++ b/docs/error/MissingXhtmlDiv.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing xhtml:div</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NoBlink.html
+++ b/docs/error/NoBlink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>There is no blink element in RSS</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NoThrWhen.html
+++ b/docs/error/NoThrWhen.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>thr:when attribute obsolete; use thr:updated instead</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NotBase64.html
+++ b/docs/error/NotBase64.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo claims to be base64-encoded, but isn't</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NotEnoughHoursInTheDay.html
+++ b/docs/error/NotEnoughHoursInTheDay.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>skipHours can not contain more than 24 hour elements</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NotEscaped.html
+++ b/docs/error/NotEscaped.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo claims to be escaped, but isn't</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NotInANamespace.html
+++ b/docs/error/NotInANamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing namespace for foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/NotURLEncoded.html
+++ b/docs/error/NotURLEncoded.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>searchTerms must be URL encoded</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/ObsoleteNamespace.html
+++ b/docs/error/ObsoleteNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed uses an obsolete namespace</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/SAXError.html
+++ b/docs/error/SAXError.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>XML Parsing error: syntax error</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/SinceAfterUntil.html
+++ b/docs/error/SinceAfterUntil.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Since After until</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/TooLong.html
+++ b/docs/error/TooLong.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>length of nnn exceeds the maximum allowable for foo of mmm</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/TooMany.html
+++ b/docs/error/TooMany.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo contains more than ten bar elements</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UndeclaredPrefix.html
+++ b/docs/error/UndeclaredPrefix.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Undeclared foo prefix: bar</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -34,7 +31,7 @@ prefixes are case-sensitive.</p>
 <p>Correct the typo, or declare the prefix with an <code>xmlns:</code>
 attribute, for example:</p>
 <blockquote>
-<pre>&lt;Url type="application/rss+xml" 
+<pre>&lt;Url type="application/rss+xml"
      <span style="background-color:yellow">xmlns:example=</span>"http://example.com/opensearchextensions/1.0/"
      template="http://example.com?f={<span style="background-color:yellow">example:</span>format?}"/&gt;</pre>
 </blockquote>

--- a/docs/error/UndefinedElement.html
+++ b/docs/error/UndefinedElement.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Undefined parent element: child</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UndefinedNamedEntity.html
+++ b/docs/error/UndefinedNamedEntity.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Undefined named entity: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UnexpectedAttribute.html
+++ b/docs/error/UnexpectedAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unexpected foo attribute on bar element</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UnexpectedText.html
+++ b/docs/error/UnexpectedText.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unexpected text</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UnexpectedWhitespace.html
+++ b/docs/error/UnexpectedWhitespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Whitespace not permitted here</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UnicodeError.html
+++ b/docs/error/UnicodeError.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>UnicodeError: decoding error, invalid data</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UnknownEncoding.html
+++ b/docs/error/UnknownEncoding.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unknown XML character encoding: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UriNotIri.html
+++ b/docs/error/UriNotIri.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>IRI found where URL expected</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/UseZeroForUnknown.html
+++ b/docs/error/UseZeroForUnknown.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Use zero for unknown length</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/ValidatorLimit.html
+++ b/docs/error/ValidatorLimit.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unable to validate, due to hardcoded resource limits (limit)</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/error/WPBlankLine.html
+++ b/docs/error/WPBlankLine.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Blank line before XML declaration (WordPress)</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -42,7 +39,7 @@ for quite a while.</p>
 blank lines outside of <code>&lt;?</code> and <code>?&gt;</code> bracketed sections.</li>
 <li>Check your <code>wp-config.php</code> file for
 blank lines outside of <code>&lt;?</code> and <code>?&gt;</code> bracketed sections.</li>
-<li>Check your theme's <code>functions.php</code> file for 
+<li>Check your theme's <code>functions.php</code> file for
 blank lines outside of <code>&lt;?</code> and <code>?&gt;</code> bracketed sections.</li>
 <li>One by one, disable plugins and revalidate until you isolate the one causing the problem.</li>
 </ul>

--- a/docs/howto/declare_namespaces.html
+++ b/docs/howto/declare_namespaces.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>How do I declare namespaces in my feed?</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/howto/install_and_run.html
+++ b/docs/howto/install_and_run.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>How do I install and run the Feed Validator?</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -166,7 +165,7 @@ can also specify a single test by filename).</p>
 
 <div class="centered">
 <address>Copyright © 2002-6
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/docs/howto/resources.html
+++ b/docs/howto/resources.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html lang="en">
 <head>
 <title>Places where you can find help</title>
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
@@ -67,7 +67,7 @@
 
 <div class="centered">
 <address>Copyright © 2002-7
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Documentation</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../css/common.css";
+<style media="screen">@import "../css/common.css";
 @import "../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 
@@ -329,7 +326,7 @@
         <img class="borderBL" src="../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/docs/info/NonstdEncoding.html
+++ b/docs/info/NonstdEncoding.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>This encoding is not mandated by the XML specification: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/info/W3CDTFDateNonUTC.html
+++ b/docs/info/W3CDTFDateNonUTC.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Date should be a UTC date</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/rfc4287.html
+++ b/docs/rfc4287.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01//EN">
-<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1"><title>The Atom Syndication Format</title><style type="text/css" title="Xml2Rfc (sans serif)">
+<html lang="en"><head><meta charset="utf-8"><title>The Atom Syndication Format</title><style type="text/css" title="Xml2Rfc (sans serif)">
 a {
   text-decoration: none;
 }
@@ -15,7 +15,7 @@ address {
   font-style: normal;
 }
 body {
-  
+
   color: #000000;
   font-family: verdana, helvetica, arial, sans-serif;
   font-size: 10pt;
@@ -101,7 +101,7 @@ td.top {
 }
 td.topnowrap {
   vertical-align: top;
-  white-space: nowrap; 
+  white-space: nowrap;
 }
 td.right {
   text-align: right;
@@ -205,7 +205,7 @@ li.indline1 {
   .noprint {
     display: none;
   }
-  
+
   table.header {
     width: 90%;
   }
@@ -230,11 +230,11 @@ li.indline1 {
   ul.toc a::after {
     content: leader('.') target-counter(attr(href), page);
   }
-  
+
   a.iref {
     content: target-counter(attr(href), page);
   }
-  
+
   .print2col {
     column-count: 2;
     -moz-column-count: 2;
@@ -243,26 +243,26 @@ li.indline1 {
 
 @page {
   @top-left {
-       content: "RFC 4287"; 
-  } 
+       content: "RFC 4287";
+  }
   @top-right {
-       content: "December 2005"; 
-  } 
+       content: "December 2005";
+  }
   @top-center {
-       content: "Atom Format"; 
-  } 
+       content: "Atom Format";
+  }
   @bottom-left {
-       content: "Nottingham & Sayre"; 
-  } 
+       content: "Nottingham & Sayre";
+  }
   @bottom-center {
-       content: "Standards Track"; 
-  } 
+       content: "Standards Track";
+  }
   @bottom-right {
-       content: "[Page " counter(page) "]"; 
-  } 
+       content: "[Page " counter(page) "]";
+  }
 }
 
-@page:first { 
+@page:first {
     @top-left {
       content: normal;
     }
@@ -277,12 +277,12 @@ li.indline1 {
 &lt;?xml version="1.0" encoding="utf-8"?&gt;
 &lt;feed xmlns="http://www.w3.org/2005/Atom"&gt;
 
-  &lt;title&gt;Example Feed&lt;/title&gt; 
+  &lt;title&gt;Example Feed&lt;/title&gt;
   &lt;link href="http://example.org/"/&gt;
   &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
-  &lt;author&gt; 
+  &lt;author&gt;
     &lt;name&gt;John Doe&lt;/name&gt;
-  &lt;/author&gt; 
+  &lt;/author&gt;
   &lt;id&gt;urn:uuid:60a76c80-d399-11d9-b93C-0003939e0af6&lt;/id&gt;
 
   &lt;entry&gt;
@@ -303,9 +303,9 @@ li.indline1 {
   &lt;/subtitle&gt;
   &lt;updated&gt;2005-07-31T12:29:29Z&lt;/updated&gt;
   &lt;id&gt;tag:example.org,2003:3&lt;/id&gt;
-  &lt;link rel="alternate" type="text/html" 
+  &lt;link rel="alternate" type="text/html"
    hreflang="en" href="http://example.org/"/&gt;
-  &lt;link rel="self" type="application/atom+xml" 
+  &lt;link rel="self" type="application/atom+xml"
    href="http://example.org/feed.atom"/&gt;
   &lt;rights&gt;Copyright (c) 2003, Mark Pilgrim&lt;/rights&gt;
   &lt;generator uri="http://www.example.com/" version="1.0"&gt;
@@ -313,7 +313,7 @@ li.indline1 {
   &lt;/generator&gt;
   &lt;entry&gt;
     &lt;title&gt;Atom draft-07 snapshot&lt;/title&gt;
-    &lt;link rel="alternate" type="text/html" 
+    &lt;link rel="alternate" type="text/html"
      href="http://example.org/2005/04/02/atom"/&gt;
     &lt;link rel="enclosure" type="audio/mpeg" length="1337"
      href="http://example.org/audio/ph34r_my_podcast.mp3"/&gt;
@@ -331,7 +331,7 @@ li.indline1 {
     &lt;contributor&gt;
       &lt;name&gt;Joe Gregorio&lt;/name&gt;
     &lt;/contributor&gt;
-    &lt;content type="xhtml" xml:lang="en" 
+    &lt;content type="xhtml" xml:lang="en"
      xml:base="http://diveintomark.org/"&gt;
       &lt;div xmlns="http://www.w3.org/1999/xhtml"&gt;
         &lt;p&gt;&lt;i&gt;[Update: The Atom draft is finished.]&lt;/i&gt;&lt;/p&gt;
@@ -339,7 +339,7 @@ li.indline1 {
     &lt;/content&gt;
   &lt;/entry&gt;
 &lt;/feed&gt;</pre> <h2 id="rfc.section.1.2"><a href="#rfc.section.1.2">1.2</a> <a name="namespace.and.version" href="#namespace.and.version">Namespace and Version</a></h2><p id="rfc.section.1.2.p.1">The XML Namespaces URI <a href="#W3C.REC-xml-names-19990114" title="Namespaces in XML">[W3C.REC-xml-names-19990114]</a> for the XML data format described in this specification is:</p><p id="rfc.section.1.2.p.2">http://www.w3.org/2005/Atom</p><p id="rfc.section.1.2.p.3">For convenience, this data format may be referred to as "Atom 1.0". This specification uses "Atom" internally.</p><h2 id="rfc.section.1.3"><a href="#rfc.section.1.3">1.3</a> Notational Conventions</h2><p id="rfc.section.1.3.p.1">This specification describes conformance in terms of two artifacts: Atom Feed Documents and Atom Entry Documents. Additionally, it places some requirements on Atom Processors.</p><p id="rfc.section.1.3.p.2">This specification uses the namespace prefix "atom:" for the Namespace URI identified in <a href="#namespace.and.version" title="Namespace and Version">Section 1.2</a>, above. Note that the choice of namespace prefix is arbitrary and not semantically significant.</p><p id="rfc.section.1.3.p.3">Atom is specified using terms from the XML Infoset <a href="#W3C.REC-xml-infoset-20040204" title="XML Information Set (Second Edition)">[W3C.REC-xml-infoset-20040204]</a>. However, this specification uses a shorthand for two common terms: the phrase "Information Item" is omitted when naming Element Information Items and Attribute Information Items. Therefore, when this specification uses the term "element," it is referring to an Element Information Item in Infoset terms. Likewise, when it uses the term "attribute," it is referring to an Attribute Information Item.</p><p id="rfc.section.1.3.p.4">Some sections of this specification are illustrated with fragments of a non-normative RELAX NG Compact schema <a href="#RELAX-NG" title="RELAX NG Compact Syntax">[RELAX-NG]</a>. However, the text of this specification provides the definition of conformance. A complete schema appears in <a href="#schema" title="RELAX NG Compact Schema">Appendix B</a>.</p><p id="rfc.section.1.3.p.5">The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14, <a href="#RFC2119" title="Key words for use in RFCs to Indicate Requirement Levels">[RFC2119]</a>, as scoped to those conformance targets.</p><h1 id="rfc.section.2"><a href="#rfc.section.2">2.</a> <a name="atom.documents" href="#atom.documents">Atom Documents</a></h1><p id="rfc.section.2.p.1">This specification describes two kinds of Atom Documents: Atom Feed Documents and Atom Entry Documents.</p><p id="rfc.section.2.p.2">An Atom Feed Document is a representation of an Atom feed, including metadata about the feed, and some or all of the entries associated with it. Its root is the <a href="#element.feed">atom:feed</a> element.</p><p id="rfc.section.2.p.3">An Atom Entry Document represents exactly one Atom entry, outside of the context of an Atom feed. Its root is the <a href="#element.entry">atom:entry</a> element.</p><div id="rfc.figure.u.3"></div> <pre>
-namespace atom = "http://www.w3.org/2005/Atom"	 		
+namespace atom = "http://www.w3.org/2005/Atom"
 start = <a href="#element.feed">atomFeed</a> | <a href="#element.entry">atomEntry</a></pre> <p id="rfc.section.2.p.5">Both kinds of Atom Documents are specified in terms of the XML Information Set, serialized as XML 1.0 <a href="#W3C.REC-xml-20040204" title="Extensible Markup Language (XML) 1.0 (Third Edition)">[W3C.REC-xml-20040204]</a> and identified with the "application/atom+xml" media type. Atom Documents MUST be well-formed XML. This specification does not define a DTD for Atom Documents, and hence does not require them to be valid (in the sense used by XML).</p><p id="rfc.section.2.p.6">Atom allows the use of IRIs <a href="#RFC3987" title="Internationalized Resource Identifiers (IRIs)">[RFC3987]</a>. Every URI <a href="#RFC3986" title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</a> is also an IRI, so a URI may be used wherever below an IRI is named. There are two special considerations: (1) when an IRI that is not also a URI is given for dereferencing, it MUST be mapped to a URI using the steps in Section 3.1 of <a href="#RFC3987" title="Internationalized Resource Identifiers (IRIs)">[RFC3987]</a> and (2) when an IRI is serving as an <a href="#element.id">atom:id</a> value, it MUST NOT be so mapped, so that the comparison works as described in <a href="#idCompare" title="Comparing atom:id">Section 4.2.6.1</a>.</p><p id="rfc.section.2.p.7">Any element defined by this specification MAY have an xml:base attribute <a href="#W3C.REC-xmlbase-20010627" title="XML Base">[W3C.REC-xmlbase-20010627]</a>. When xml:base is used in an Atom Document, it serves the function described in section 5.1.1 of <a href="#RFC3986" title="Uniform Resource Identifier (URI): Generic Syntax">[RFC3986]</a>, establishing the base URI (or IRI) for resolving any relative references found within the effective scope of the xml:base attribute.</p><p id="rfc.section.2.p.8">Any element defined by this specification MAY have an xml:lang attribute, whose content indicates the natural language for the element and its descendents. The language context is only significant for elements and attributes declared to be "Language-Sensitive" by this specification. Requirements regarding the content and interpretation of xml:lang are specified in <a href="#W3C.REC-xml-20040204">XML 1.0</a> [W3C.REC-xml-20040204], Section 2.12. </p><div id="rfc.figure.u.4"></div> <a name="rfc.iref.1"></a>  <a name="rfc.iref.2"></a>  <pre>
 <a href="#atom.documents">atomCommonAttributes</a> =
    attribute xml:base { atomUri }?,
@@ -384,7 +384,7 @@ start = <a href="#element.feed">atomFeed</a> | <a href="#element.entry">atomEntr
    &lt;xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"&gt;
       This is &lt;xhtml:b&gt;XHTML&lt;/xhtml:b&gt; content.
    &lt;/xhtml:div&gt;
-&lt;/summary&gt; 
+&lt;/summary&gt;
 ...</pre> <p id="rfc.section.3.1.1.3.p.4">The following example assumes that the XHTML namespace has been bound to the "xh" prefix earlier in the document: </p><div id="rfc.figure.u.10"></div> <pre>
 ...
 &lt;summary type="xhtml"&gt;
@@ -486,7 +486,7 @@ start = <a href="#element.feed">atomFeed</a> | <a href="#element.entry">atomEntr
    &lt;xhtml:div xmlns:xhtml="http://www.w3.org/1999/xhtml"&gt;
       This is &lt;xhtml:b&gt;XHTML&lt;/xhtml:b&gt; content.
    &lt;/xhtml:div&gt;
-&lt;/content&gt; 
+&lt;/content&gt;
 ...</pre> <p id="rfc.section.4.1.3.4.p.3">The following example assumes that the XHTML namespace has been bound to the "xh" prefix earlier in the document: </p><div id="rfc.figure.u.18"></div> <pre>
 ...
 &lt;content type="xhtml"&gt;

--- a/docs/rss2.html
+++ b/docs/rss2.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>RSS 2.0 specification</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../css/common.css";
+<style media="screen">@import "../css/common.css";
 @import "../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 
@@ -437,7 +436,7 @@ This document and the information contained herein is provided on an "AS IS" bas
         <img class="borderBL" src="../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 </body>

--- a/docs/rss2.tmpl
+++ b/docs/rss2.tmpl
@@ -1,7 +1,7 @@
 <$MTInclude module="doctype"$>
 <head>
+<meta charset="utf-8">
 <title>RSS 2.0 specification</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <$MTInclude module="css"$>
 </head>
 <body>

--- a/docs/terms.tmpl
+++ b/docs/terms.tmpl
@@ -1,7 +1,7 @@
 <$MTInclude module="doctype"$>
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Terms of Use</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <$MTInclude module="css"$>
 </head>
 <body>

--- a/docs/warning/ArchiveIncomplete.html
+++ b/docs/warning/ArchiveIncomplete.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Archive incomplete</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/AtomLinkNotEmpty.html
+++ b/docs/warning/AtomLinkNotEmpty.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo should not have text (all data is in attributes)</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/AttrNotBlank.html
+++ b/docs/warning/AttrNotBlank.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo attribute of bar should not be blank</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/AvoidNamespacePrefix.html
+++ b/docs/warning/AvoidNamespacePrefix.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Avoid Namespace Prefix: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -26,7 +23,7 @@
 <h2>Explanation</h2>
 
 <div class="docbody">
-<p>While 
+<p>While
 <a href="http://www.w3.org/TR/REC-xml-names/">XML Namespaces</a> permits the
 declaration of prefixes for namespaces such as
 <code title="http://www.w3.org/2005/Atom">atom</code> and

--- a/docs/warning/AvoidTextInput.html
+++ b/docs/warning/AvoidTextInput.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Avoid Text Input</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/BadCharacters.html
+++ b/docs/warning/BadCharacters.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>The XML encoding does not appear to match the characters used.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/CharacterData.html
+++ b/docs/warning/CharacterData.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>Encode "&" and "<" in plain text using hexadecimal character references.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/CommentRSS.html
+++ b/docs/warning/CommentRSS.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>wfw:commentRSS should be wfw:commentRss</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ContainsEmail.html
+++ b/docs/warning/ContainsEmail.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>name should not contain email address</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ContainsHTML.html
+++ b/docs/warning/ContainsHTML.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element should not contain HTML</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ContainsRelRef.html
+++ b/docs/warning/ContainsRelRef.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element should not contain relative URL references</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ContainsUndeclaredHTML.html
+++ b/docs/warning/ContainsUndeclaredHTML.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo should not contain HTML unless declared in the type attribute</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/CoordComma.html
+++ b/docs/warning/CoordComma.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Comma found in coordinate pair</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DangerousStyleAttr.html
+++ b/docs/warning/DangerousStyleAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>style attribute contains potentially dangerous content</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -115,7 +112,7 @@ constructs should be avoided.</p>
 <div class="docbody">
 <p>Consider simplifying or completely removing the potentially unsafe
 <code>style</code> attribute.  At a minimum, ensure that your content will
-still display as intended if this attribute is stripped by 
+still display as intended if this attribute is stripped by
 <a href="http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely">security conscious clients</a>.</p>
 </div>
 <h2>Not clear?  Disagree?</h2>

--- a/docs/warning/Deprecated.html
+++ b/docs/warning/Deprecated.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo has been superceded by foo.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DeprecatedMediaAdult.html
+++ b/docs/warning/DeprecatedMediaAdult.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>media:adult is deprecated</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DeprecatedRootHref.html
+++ b/docs/warning/DeprecatedRootHref.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>root:// URLs have been superceded by full http:// URLs</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DuplicateDescriptionSemantics.html
+++ b/docs/warning/DuplicateDescriptionSemantics.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Avoid foo:bar</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DuplicateEnclosure.html
+++ b/docs/warning/DuplicateEnclosure.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>item contains more than one enclosure</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DuplicateEntries.html
+++ b/docs/warning/DuplicateEntries.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Two entries with the same id</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DuplicateItemSemantics.html
+++ b/docs/warning/DuplicateItemSemantics.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>An item should not include both foo and bar</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DuplicateSemantics.html
+++ b/docs/warning/DuplicateSemantics.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>A channel should not include both foo and bar</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/DuplicateUpdated.html
+++ b/docs/warning/DuplicateUpdated.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Two entries with the same value for atom:updated</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/EmailFormat.html
+++ b/docs/warning/EmailFormat.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Email address is not in the recommended format</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/EncodingMismatch.html
+++ b/docs/warning/EncodingMismatch.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Your feed appears to be encoded as &#8220;this&#8221;, but your server is reporting &#8220;that&#8221;</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -54,7 +51,7 @@ Your feed appears to be encoded as &ldquo;utf-8&rdquo;, but your server is repor
 declaration</a>, or ensure that the server makes no claims
 about the encoding. Serving the feed as <code>application/xml</code> means
 that the encoding will be taken from the file's declaration.</p>
-<p>The W3C has 
+<p>The W3C has
 <a href="http://www.w3.org/International/O-HTTP-charset">published
 information</a> on how to set the HTTP charset parameter with various popular
 web servers.</p>

--- a/docs/warning/FeedHistoryRelInEntry.html
+++ b/docs/warning/FeedHistoryRelInEntry.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo link relation found in entry</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -27,7 +24,7 @@
 
 <div class="docbody">
 <p><a href="http://www.ietf.org/rfc/rfc5005.txt">RFC 5005</a> defines these
-relations in the context of a "Head section" 
+relations in the context of a "Head section"
 (e.g., the child elements of the atom:feed element in an Atom Feed Document)
 but in this feed, archive and/or history links were found outside of the
 head section.</p>

--- a/docs/warning/HtmlFragment.html
+++ b/docs/warning/HtmlFragment.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>type foo/bar used for a document fragment</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -26,7 +23,7 @@
 <h2>Explanation</h2>
 
 <div class="docbody">
-<p>The Mime type specified is meant to describe a complete document, 
+<p>The Mime type specified is meant to describe a complete document,
 (i.e., including a beginning <code>&lt;html&gt;</code> tag).</p>
 </div>
 <h2>Solution</h2>

--- a/docs/warning/ImageLinkDoesntMatch.html
+++ b/docs/warning/ImageLinkDoesntMatch.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Image link doesn't match channel link</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ImageTitleDoesntMatch.html
+++ b/docs/warning/ImageTitleDoesntMatch.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Image title doesn't match channel title</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ImageUrlFormat.html
+++ b/docs/warning/ImageUrlFormat.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Image not in required format</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ImplausibleDate.html
+++ b/docs/warning/ImplausibleDate.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Implausible date: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/InvalidAdultContent.html
+++ b/docs/warning/InvalidAdultContent.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Non-boolean value for AdultContent: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/InvalidKeywords.html
+++ b/docs/warning/InvalidKeywords.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Use commas to separate keywords</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/InvalidKmlMediaType.html
+++ b/docs/warning/InvalidKmlMediaType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is an invalid KML media type. Use application/vnd.google-earth.kml+xml or application/vnd.google-earth.kmz</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/InvalidOutlineType.html
+++ b/docs/warning/InvalidOutlineType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>The type attribute on an <outline> element should be a known type.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/InvalidOutlineVersion.html
+++ b/docs/warning/InvalidOutlineVersion.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>An <outline> element whose type is "rss" may have a version attribute, whose value must be RSS, RSS1, RSS2, or scriptingNews.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MisplacedItem.html
+++ b/docs/warning/MisplacedItem.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Misplaced Item</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MisplacedXHTMLContent.html
+++ b/docs/warning/MisplacedXHTMLContent.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Misplaced XHTML content</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingAtomSelfLink.html
+++ b/docs/warning/MissingAtomSelfLink.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing atom:link with rel="self"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingCurrentInArchive.html
+++ b/docs/warning/MissingCurrentInArchive.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>current link not found in archive feed</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingEncoding.html
+++ b/docs/warning/MissingEncoding.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>No character encoding was specified</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingGuid.html
+++ b/docs/warning/MissingGuid.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>item should contain a guid element</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -45,7 +42,7 @@ the article, and &lt;guid&gt; is the permalink to the weblog entry.</p>
 </div>
 <h2>Solution</h2>
 <div class="docbody">
-<p>Add a different, unique, and unchanging 
+<p>Add a different, unique, and unchanging
 <a href="http://feedvalidator.org/docs/rss2.html#ltguidgtSubelementOfLtitemgt">guid</a> to each item.  See <a href="http://scripting.com/rss.xml">scripting.com</a> for an example.</p>
 </div>
 <h2>Not clear?  Disagree?</h2>

--- a/docs/warning/MissingId.html
+++ b/docs/warning/MissingId.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Placemark should contain a id attribute</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingItunesElement.html
+++ b/docs/warning/MissingItunesElement.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing recommended iTunes parent element: child</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingItunesEmail.html
+++ b/docs/warning/MissingItunesEmail.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>The recommended <itunes:email> element is missing</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingOutlineType.html
+++ b/docs/warning/MissingOutlineType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>An <outline> element with more than just a "text" attribute should have a "type" attribute indicating how the other attributes are to be interpreted.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingRealName.html
+++ b/docs/warning/MissingRealName.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Email address is missing real name</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingRecommendedAttribute.html
+++ b/docs/warning/MissingRecommendedAttribute.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing recommended element attribute: name</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingSelf.html
+++ b/docs/warning/MissingSelf.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing atom:link with rel="self"</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingSourceElement.html
+++ b/docs/warning/MissingSourceElement.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing source element: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingTextualContent.html
+++ b/docs/warning/MissingTextualContent.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing Textual Content</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingTitleAttr.html
+++ b/docs/warning/MissingTitleAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing outline attribute: title</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -27,8 +24,8 @@
 
 <div class="docbody">
 <p>From the
-<a href="http://www.opml.org/guidelinesForValidation">Guidelines for validating OPML</a>, in the 
-<a href="http://www.opml.org/guidelinesForValidation#subscriptionLists"> subscription lists</a> section: 
+<a href="http://www.opml.org/guidelinesForValidation">Guidelines for validating OPML</a>, in the
+<a href="http://www.opml.org/guidelinesForValidation#subscriptionLists"> subscription lists</a> section:
 <blockquote>title is probably the same as text, it should not be omitted.</blockquote>
 </p>
 </div>

--- a/docs/warning/MissingTypeAttr.html
+++ b/docs/warning/MissingTypeAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing content attribute: type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingUrlAttr.html
+++ b/docs/warning/MissingUrlAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing outline attribute: url</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/MissingXmlURL.html
+++ b/docs/warning/MissingXmlURL.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
 <title>An <outline> element whose type is "rss" must have an "xmlUrl" attribute.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<meta charset="utf-8">
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/NeedDescriptionBeforeContent.html
+++ b/docs/warning/NeedDescriptionBeforeContent.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Ensure description precedes content:encoded</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/NonCanonicalURI.html
+++ b/docs/warning/NonCanonicalURI.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Identifier &#8220;foo&#8221; is not in canonical form (tha canonical form would be &#8220;bar&#8221;)</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/NonSpecificMediaType.html
+++ b/docs/warning/NonSpecificMediaType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>'type/subtype' media type is not specific enough</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -37,7 +34,7 @@ a feed.</p>
 <p>RSS feeds should be served as <code>application/rss+xml</code>.
 Atom feeds should use <code>application/atom+xml</code>.</p>
 <ul>
-<li>For static content served with Apache, use the 
+<li>For static content served with Apache, use the
 <a href="http://httpd.apache.org/docs/mod/mod_mime.html#addtype">AddType</a>
 directive.</li>
 <li>For static content served with Microsoft IIS,

--- a/docs/warning/NotBlank.html
+++ b/docs/warning/NotBlank.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element should not be blank</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/NotHtml.html
+++ b/docs/warning/NotHtml.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Invalid HTML: explanation</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -29,13 +26,13 @@
 <p>Common causes for this condition:</p>
 <ul>
 <li>Placing plain text in an element intended to be rendered as HTML.
-Example: representing a less than sign ("&lt;") as escaped HTML 
+Example: representing a less than sign ("&lt;") as escaped HTML
 requires the following code: <code>&amp;amp;lt;</code></li>
 <li>Use of non-HTML tags.</li>
 <li>Arbitrary truncation of HTML, possibly in the middle of a tag.</li>
-<li>Unmatched quotes in attribute values, or missing whitespace between 
+<li>Unmatched quotes in attribute values, or missing whitespace between
 attributes</li>
-<li>For Atom feeds: declaring the 
+<li>For Atom feeds: declaring the
 <code>type</code> as <code>xhtml</code>, but not changing
 the default namespace from atom's to xhtml's.</li>
 </ul>
@@ -46,7 +43,7 @@ the default namespace from atom's to xhtml's.</li>
 <code>description</code>, make sure that all plain text content is escaped
 first as HTML and then again as XML.</p>
 <p>For Atom text constructs, you can use the <code>type</code> attribute
-to declare your intented usage: plain <code>text</code>, 
+to declare your intented usage: plain <code>text</code>,
 escaped <code>html</code> or in-line <code>xhtml</code>.</p>
 </div>
 <h2>Not clear?  Disagree?</h2>

--- a/docs/warning/NotInline.html
+++ b/docs/warning/NotInline.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo claims to be inline, but may contain HTML.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/NotSufficientlyUnique.html
+++ b/docs/warning/NotSufficientlyUnique.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>The specified guid is not sufficiently unique.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/NotUTF8.html
+++ b/docs/warning/NotUTF8.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>iTunes elements should only be present in feeds encoded as UTF-8</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ObscureEncoding.html
+++ b/docs/warning/ObscureEncoding.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Obscure XML character encoding: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ObsoleteItunesCategory.html
+++ b/docs/warning/ObsoleteItunesCategory.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>foo is an obsolete iTunes category or sub-category</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ObsoleteVersion.html
+++ b/docs/warning/ObsoleteVersion.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed is an obsolete version</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ObsoleteWikiNamespace.html
+++ b/docs/warning/ObsoleteWikiNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Obsolete Wiki Namespace</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ProblematicalRFC822Date.html
+++ b/docs/warning/ProblematicalRFC822Date.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Problematical RFC 822 date-time value</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/QuestionableUsage.html
+++ b/docs/warning/QuestionableUsage.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Undocumented use of element</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/RelativeSelf.html
+++ b/docs/warning/RelativeSelf.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Relative href value on self link</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ReservedPrefix.html
+++ b/docs/warning/ReservedPrefix.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>The prefix name generally is associated with the namespace http://some/other/namespace</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/SameDocumentReference.html
+++ b/docs/warning/SameDocumentReference.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Same-document reference</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -34,7 +31,7 @@ different clients.</p>
 </div>
 <h2>Solution</h2>
 <div class="docbody">
-<p>Consider changing the xml:base to reference the either the 
+<p>Consider changing the xml:base to reference the either the
 document itself, or the parent directory of the document referenced.</p>
 <p>For example, change:</p>
 <blockquote><code>&lt;link href="." xml:base="http://example.com/blog/" /&gt;</code></blockquote>

--- a/docs/warning/SchemeNotIANARegistered.html
+++ b/docs/warning/SchemeNotIANARegistered.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>URI scheme not IANA registered: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/SecurityRisk.html
+++ b/docs/warning/SecurityRisk.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element should not contain script tag</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -47,7 +44,7 @@
 <div class="docbody">
 <p>Remove the offending HTML tags.
 At a minimum, ensure that your content will still display as intended
-if this element is stripped by 
+if this element is stripped by
 <a href="http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely">security conscious clients</a>.</p>
 </div>
 <h2>Not clear?  Disagree?</h2>

--- a/docs/warning/SecurityRiskAttr.html
+++ b/docs/warning/SecurityRiskAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>element should not contain script attribute</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -110,7 +107,7 @@ white-list approach, and only accepts the following attributes:</p>
 <div class="docbody">
 <p>Consider removing the potentially unsafe HTML attribute.
 At a minimum, ensure that your content will still display as intended
-if this attribute is stripped by 
+if this attribute is stripped by
 <a href="http://diveintomark.org/archives/2003/06/12/how_to_consume_rss_safely">security conscious clients</a>.</p>
 </div>
 <h2>Not clear?  Disagree?</h2>

--- a/docs/warning/SelfDoesntMatchLocation.html
+++ b/docs/warning/SelfDoesntMatchLocation.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Self reference doesn't match document location</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/SelfNotAtom.html
+++ b/docs/warning/SelfNotAtom.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>"self" link references a non-Atom representation.</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/ShouldIncludeExample.html
+++ b/docs/warning/ShouldIncludeExample.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>OpenSearchDescription should include an example Query</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/SlashDate.html
+++ b/docs/warning/SlashDate.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Ensure lastBuildDate is present when slash:comments is used</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UndefinedParam.html
+++ b/docs/warning/UndefinedParam.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Undefined media-range parameter</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UndeterminableVocabulary.html
+++ b/docs/warning/UndeterminableVocabulary.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Missing namespace for foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UnexpectedContentType.html
+++ b/docs/warning/UnexpectedContentType.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feeds should not be served with the 'type/subtype' media type</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>
@@ -42,7 +39,7 @@ general XML types -  preferably <code>application/xml</code>.</p>
 <div class="docbody">
 <p>Use the appropriate MIME type for your feed.</p>
 <ul>
-<li>For static content served with Apache, use the 
+<li>For static content served with Apache, use the
 <a href="http://httpd.apache.org/docs/mod/mod_mime.html#addtype">AddType</a>
 directive.</li>
 <li>For static content served with Microsoft IIS,

--- a/docs/warning/UnknownHost.html
+++ b/docs/warning/UnknownHost.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unknown host: name</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UnknownNamespace.html
+++ b/docs/warning/UnknownNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Use of unknown namespace: http://namespace.uri/</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UnregisteredAtomLinkRel.html
+++ b/docs/warning/UnregisteredAtomLinkRel.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unregistered link relationship: foo</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UnsupportedItunesFormat.html
+++ b/docs/warning/UnsupportedItunesFormat.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Format foo is not supported by iTunes</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UnsupportedNamespace.html
+++ b/docs/warning/UnsupportedNamespace.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unable to validate namespace: http://namespace.uri/. See the foo specification at http://namespace.uri/specification</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UseOfExtensionAttr.html
+++ b/docs/warning/UseOfExtensionAttr.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Use of extension attribute on RSS 2.0 core element: (namespace,name)</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/docs/warning/UseZeroForMidnight.html
+++ b/docs/warning/UseZeroForMidnight.html
@@ -1,14 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Use zero for midnight</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/docs/" title="Home" />
 </head>
 <body>

--- a/news/archives/2002/10/21/live.html
+++ b/news/archives/2002/10/21/live.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Live - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/22/known_bugs.html" title="Known bugs" />
@@ -51,7 +50,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/22/known_bugs.html
+++ b/news/archives/2002/10/22/known_bugs.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Known bugs - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/21/live.html" title="Live" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/22/version_101_released.html" title="Version 1.0.1 released" />
@@ -58,7 +57,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/22/unicode_errors.html
+++ b/news/archives/2002/10/22/unicode_errors.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Unicode errors - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/22/version_101_released.html" title="Version 1.0.1 released" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/22/version_102.html" title="Version 1.0.2" />
@@ -53,7 +52,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/22/version_101_released.html
+++ b/news/archives/2002/10/22/version_101_released.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.0.1 released - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/22/known_bugs.html" title="Known bugs" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/22/unicode_errors.html" title="Unicode errors" />
@@ -51,7 +50,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/22/version_102.html
+++ b/news/archives/2002/10/22/version_102.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.0.2 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/22/unicode_errors.html" title="Unicode errors" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/22/version_103.html" title="Version 1.0.3" />
@@ -59,7 +58,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/22/version_103.html
+++ b/news/archives/2002/10/22/version_103.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.0.3 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/22/version_102.html" title="Version 1.0.2" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/24/version_104.html" title="Version 1.0.4" />
@@ -58,7 +57,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/24/version_104.html
+++ b/news/archives/2002/10/24/version_104.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.0.4 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/22/version_103.html" title="Version 1.0.3" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/29/version_105.html" title="Version 1.0.5" />
@@ -59,7 +58,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/29/new_mailing_list_for_validator_users.html
+++ b/news/archives/2002/10/29/new_mailing_list_for_validator_users.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>New mailing list for validator users - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/29/version_105.html" title="Version 1.0.5" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2003/07/09/preliminary_pie_support.html" title="Preliminary Pie support" />
@@ -53,7 +52,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2002/10/29/version_105.html
+++ b/news/archives/2002/10/29/version_105.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.0.5 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/24/version_104.html" title="Version 1.0.4" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2002/10/29/new_mailing_list_for_validator_users.html" title="New mailing list for validator users" />
@@ -57,7 +56,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2003/07/09/preliminary_pie_support.html
+++ b/news/archives/2003/07/09/preliminary_pie_support.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Preliminary Pie support - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2002/10/29/new_mailing_list_for_validator_users.html" title="New mailing list for validator users" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2003/07/28/version_111_bugfixes.html" title="Version 1.11, bugfixes" />
@@ -55,7 +54,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2003/07/28/version_111_bugfixes.html
+++ b/news/archives/2003/07/28/version_111_bugfixes.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.11, bugfixes - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2003/07/09/preliminary_pie_support.html" title="Preliminary Pie support" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2003/08/05/version_12_supports_atom_02.html" title="Version 1.2 supports Atom 0.2" />
@@ -137,7 +136,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2003/08/05/version_121.html
+++ b/news/archives/2003/08/05/version_121.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.2.1 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2003/08/05/version_12_supports_atom_02.html" title="Version 1.2 supports Atom 0.2" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2003/08/05/version_122.html" title="Version 1.2.2" />
@@ -51,7 +50,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2003/08/05/version_122.html
+++ b/news/archives/2003/08/05/version_122.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.2.2 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2003/08/05/version_121.html" title="Version 1.2.1" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2003/12/13/version_13_supports_atom_03.html" title="Version 1.3 supports Atom 0.3" />
@@ -51,7 +50,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2003/08/05/version_12_supports_atom_02.html
+++ b/news/archives/2003/08/05/version_12_supports_atom_02.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.2 supports Atom 0.2 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "/css/common.css";
+<style media="screen">@import "/css/common.css";
 @import "/css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="http://feedvalidator.org/news/" title="Home" />
 <link rel="prev" href="http://feedvalidator.org/news/archives/2003/07/28/version_111_bugfixes.html" title="Version 1.11, bugfixes" />
 <link rel="next" href="http://feedvalidator.org/news/archives/2003/08/05/version_121.html" title="Version 1.2.1" />
@@ -1045,7 +1044,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2003/12/13/version_13_supports_atom_03.html
+++ b/news/archives/2003/12/13/version_13_supports_atom_03.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Version 1.3 supports Atom 0.3 - Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../../../../css/common.css";
+<style media="screen">@import "../../../../../css/common.css";
 @import "../../../../../css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="../../../../../news/" title="Home" />
 <link rel="prev" href="../../../../../news/archives/2003/08/05/version_122.html" title="Version 1.2.2" />
 <link rel="next" href="../../../../../news/archives/2005/07/20/beta_support_for_atom_10.html" title="Atom 1.0 Beta" />
@@ -57,7 +56,7 @@
         <img class="borderBL" src="../../../../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../../../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/archives/2005/07/20/beta_support_for_atom_10.html
+++ b/news/archives/2005/07/20/beta_support_for_atom_10.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Support for Atom 1.0 now in beta</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../../../../css/common.css";
+<style media="screen">@import "../../../../../css/common.css";
 @import "../../../../../css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="../../../../../news/" title="Home" />
 <link rel="prev" href="../../../../../news/archives/2003/12/13/version_13_supports_atom_03.html" title="Version 1.3" />
 <link rel="next" href="../../../../../news/archives/2005/09/15/atom_03_deprecated.html" title="Atom 0.3 deprecated" />
@@ -61,11 +60,11 @@
         <img class="borderBL" src="../../../../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../../../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
-<address>Copyright &copy; 2002-5 
+<address>Copyright &copy; 2002-5
 <a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and

--- a/news/archives/2005/09/15/atom_03_deprecated.html
+++ b/news/archives/2005/09/15/atom_03_deprecated.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Atom 0.3 Support Deprecated</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../../../../css/common.css";
+<style media="screen">@import "../../../../../css/common.css";
 @import "../../../../../css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="../../../../../news/" title="Home" />
 <link rel="prev" href="../../../../../news/archives/2005/07/20/beta_support_for_atom_10.html" title="Version 1.3" />
 
@@ -53,11 +52,11 @@
         <img class="borderBL" src="../../../../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../../../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
-<address>Copyright &copy; 2002-5 
+<address>Copyright &copy; 2002-5
 <a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and

--- a/news/archives/2007/10/15/rss_best_practices.html
+++ b/news/archives/2007/10/15/rss_best_practices.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Atom 0.3 Support Deprecated</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../../../../css/common.css";
+<style media="screen">@import "../../../../../css/common.css";
 @import "../../../../../css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="start" href="../../../../../news/" title="Home" />
 <link rel="prev" href="../../../../../news/archives/2005/07/20/beta_support_for_atom_10.html" title="Version 1.3" />
 
@@ -74,11 +73,11 @@ is detected:</p>
         <img class="borderBL" src="../../../../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../../../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
-<address>Copyright &copy; 2002-5 
+<address>Copyright &copy; 2002-5
 <a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and

--- a/news/archives/index.html
+++ b/news/archives/index.html
@@ -1,14 +1,13 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator News Archives</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
-<body>	
+<body>
 
 <div id="logo">
 <h1><a href="../../"><span id="feed"><span id="f">F</span><span id="e1">E</span><span id="e2">E</span></span><span id="d">D</span> Validator</a></h1>
@@ -16,7 +15,7 @@
 <a class="skip" href="#startnavigation">Jump to navigation</a>
 </div> <!--logo-->
 
-	
+
 <div id="main">
 <ul>
 <li>September 15, 2005 12:45 AM: <a href="2005/09/15/atom_03_deprecated.html">Atom 0.3 Support Deprecated</a></li>
@@ -61,7 +60,7 @@
         <img class="borderBL" src="../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/news/index.html
+++ b/news/index.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator News</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../css/common.css";
+<style media="screen">@import "../css/common.css";
 @import "../css/news.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="alternate" type="application/rss+xml" title="RSS" href="http://feedvalidator.org/news/index.xml" />
 </head>
 <body>
@@ -100,7 +99,7 @@ is detected:</p>
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/register.html
+++ b/register.html
@@ -1,8 +1,8 @@
 <!DOCTYPE html>
-<html xmlns='http://www.w3.org/1999/xhtml'>
+<html>
 <head>
 <title>Register feedvalidator.org as a Mozilla Feed Reader</title>
-<style type="text/css" media="screen">@import "css/common.css";
+<style media="screen">@import "css/common.css";
 @import "css/validator.css";</style>
 <script>
 window.navigator.registerContentHandler('application/vnd.mozilla.maybe.feed',
@@ -23,7 +23,7 @@ window.navigator.registerContentHandler('application/vnd.mozilla.maybe.feed',
 <li>An infrequent user of Firefox's feature for subscribing to feeds.</li>
 </ul>
 <p>... then you might find it useful to register the FeedValidator as a
-<q>Feed Reader</q>.  Simply follow the instructions in the popdown that appears 
+<q>Feed Reader</q>.  Simply follow the instructions in the popdown that appears
 just above the top of this page.  Once registered, you can
 validate any feed merely by <q>subscribing</q> to it.</p>
 <p>Such <q>subscriptions</q> are not persistent; if you wish to revalidate a
@@ -56,13 +56,13 @@ height="14" />
         <img class="borderBR" src="images/borderBR.gif" alt="" width="14"
 height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 
 </div><!-- .centered -->
 
 <div class="centered">
 <address>Copyright &copy; 2002-9
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/templates/header.tmpl
+++ b/templates/header.tmpl
@@ -1,15 +1,12 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>%(title)s</title>
-<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-<style type="text/css" media="screen">@import "%(CSSURL)s/common.css";
+<style media="screen">@import "%(CSSURL)s/common.css";
 @import "%(CSSURL)s/validator.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 <link rel="home" href="./" title="Home" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
 </head>
 <body>
 

--- a/templates/notsupported.tmpl
+++ b/templates/notsupported.tmpl
@@ -1,4 +1,4 @@
-<h2>Not-supported</h2>
+<h2>Not supported</h2>
 
 <p>The version of the format of this feed is not supported by this validator.</p>
 

--- a/terms.html
+++ b/terms.html
@@ -1,12 +1,11 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Terms of Use</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "css/common.css";
+<style media="screen">@import "css/common.css";
 @import "css/documentation.css";</style>
-<script type="text/javascript"><!-- --></script>
+<script><!-- --></script>
 </head>
 <body>
 
@@ -60,7 +59,7 @@
         <img class="borderBL" src="/images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="/images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">

--- a/testcases/atom/header.html
+++ b/testcases/atom/header.html
@@ -1,14 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;

--- a/testcases/atom/index.html
+++ b/testcases/atom/index.html
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Documentation</title>
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";
 ul, li {
   list-style-type: none;
@@ -167,12 +164,12 @@ ul, li {
         <img class="borderBL" src="../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
 <address>Copyright &copy; 2002-6
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/testcases/atom/must/feed_missing2.xml
+++ b/testcases/atom/must/feed_missing2.xml
@@ -9,13 +9,13 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>dive into mark</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="alternate" type="application/rss+xml" title="RSS" href="http://example.com/xml/rss.xml" />
 <link rel="stylesheet" href="/css/common.css" type="text/css" />
-<style type="text/css" media="screen">@import "/css/box.css";</style>
+<style media="screen">@import "/css/box.css";</style>
 <link rel="stylesheet" href="/css/print.css" type="text/css" media="print" />
 <link rel="home" href="/" title="Home" />
 

--- a/testcases/ext/header.html
+++ b/testcases/ext/header.html
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;
@@ -22,7 +21,7 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
+      a.href="../../../check.cgi?url=" +
         escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";

--- a/testcases/gbase/header.html
+++ b/testcases/gbase/header.html
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;
@@ -22,7 +21,7 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
+      a.href="../../../check.cgi?url=" +
         escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";

--- a/testcases/opensearch/header.html
+++ b/testcases/opensearch/header.html
@@ -1,14 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 toc = {
   "Notice": "1",
@@ -98,7 +95,7 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
+      a.href="../../../check.cgi?url=" +
         escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";

--- a/testcases/opensearch/index.html
+++ b/testcases/opensearch/index.html
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Documentation</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";
 ul,li {
   list-style-type: none;
@@ -175,12 +172,12 @@ ul,li {
         <img class="borderBL" src="../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
 <address>Copyright &copy; 2002-6
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/testcases/opml/header.html
+++ b/testcases/opml/header.html
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;
@@ -22,7 +21,7 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
+      a.href="../../../check.cgi?url=" +
         escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";

--- a/testcases/rss/header.html
+++ b/testcases/rss/header.html
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;
@@ -22,8 +21,8 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
-        escape(image.nextSibling ? image.nextSibling.nextSibling.href : 
+      a.href="../../../check.cgi?url=" +
+        escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";
       image.parentNode.replaceChild(a,image);

--- a/testcases/rss/must/missing_rss2.xml
+++ b/testcases/rss/must/missing_rss2.xml
@@ -9,13 +9,13 @@
 -->
 
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>dive into mark</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
 <link rel="alternate" type="application/rss+xml" title="RSS" href="http://example.com/xml/rss.xml" />
 <link rel="stylesheet" href="/css/common.css" type="text/css" />
-<style type="text/css" media="screen">@import "/css/box.css";</style>
+<style media="screen">@import "/css/box.css";</style>
 <link rel="stylesheet" href="/css/print.css" type="text/css" media="print" />
 <link rel="home" href="/" title="Home" />
 

--- a/testcases/rss11/header.html
+++ b/testcases/rss11/header.html
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;
@@ -22,7 +21,7 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
+      a.href="../../../check.cgi?url=" +
         escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";

--- a/testcases/rss20/header.html
+++ b/testcases/rss20/header.html
@@ -1,14 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 toc = {
   "introduction": "1",

--- a/testcases/rss20/index.html
+++ b/testcases/rss20/index.html
@@ -1,12 +1,9 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
-<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en">
+<!DOCTYPE html>
+<html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Documentation</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />
-<link rel="icon" href="http://www.feedvalidator.org/favicon.ico" />
-<link rel="shortcut icon" href="http://www.feedvalidator.org/favicon.ico" />
-<style type="text/css" media="screen">@import "../../css/common.css";
+<style media="screen">@import "../../css/common.css";
 @import "../../css/documentation.css";
 ul,li {
   list-style-type: none;
@@ -51,7 +48,7 @@ ul,li {
       <li>4.1.1.3 <a href="element-channel-title">title</a></li>
 
       <li>4.1.1.4 <a title="element-channel-category">category</a></li>
-      <li>4.1.1.5 <a href="element-channel-cloud">cloud</a></li>  
+      <li>4.1.1.5 <a href="element-channel-cloud">cloud</a></li>
       <li>4.1.1.6 <a title="element-channel-copyright">copyright</a></li>
       <li>4.1.1.7 <a href="element-channel-docs">docs</a></li>
       <li>4.1.1.8 <a title="element-channel-generator">generator</a></li>
@@ -164,12 +161,12 @@ ul,li {
         <img class="borderBL" src="../../images/borderBL.gif" alt="" width="14" height="14" />
         <img class="borderBR" src="../../images/borderBR.gif" alt="" width="14" height="14" />
     </div><!-- .bottomCorners -->
-</div><!-- .contentWrapper --> 
+</div><!-- .contentWrapper -->
 </div><!-- .centered -->
 
 <div class="centered">
 <address>Copyright &copy; 2002-6
-<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>, 
+<a href="http://www.intertwingly.net/blog/">Sam Ruby</a>,
 <a href="http://diveintomark.org/">Mark Pilgrim</a>,
 <a href="http://www.kafsemo.org/">Joseph Walton</a>, and
 <a href="http://philringnalda.com/">Phil Ringnalda</a>

--- a/testcases/xml/header.html
+++ b/testcases/xml/header.html
@@ -1,12 +1,11 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.0 Transitional//EN"
-"http://www.w3.org/TR/REC-html40/loose.dtd">
+<!DOCTYPE html>
 <html lang="en">
 <head>
+<meta charset="utf-8">
 <title>Feed Validator Test Cases</title>
-<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">
-<style type="text/css" media="screen">@import "../../../css/common.css";
+<style media="screen">@import "../../../css/common.css";
 @import "../../../css/documentation.css";</style>
-<script type="text/javascript">
+<script>
 
 window.onload=function() {
   if(!document.getElementsByTagName || !document.createElement) return;
@@ -22,7 +21,7 @@ window.onload=function() {
       image.hspace=2;
       image.vspace=1;
       var a = document.createElement('a');
-      a.href="../../../check.cgi?url=" + 
+      a.href="../../../check.cgi?url=" +
         escape(image.nextSibling ? image.nextSibling.nextSibling.href :
         image.parentNode.nextSibling.childNodes[0].href);
       image.title="validate";


### PR DESCRIPTION
I’ve mostly applied the things described here: http://mathiasbynens.be/notes/html5-levels

* Removed useless XML prologs from HTML files
* Switched to the `<!DOCTYPE html>` doctype
* Switched to `<meta charset="utf-8">` (instead of `<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />`) and moved it to the top of the `<head>`:

    > As recommended by [the HTML5 spec](http://www.whatwg.org/specs/web-apps/current-work/complete/semantics.html#charset) (4.2.5.5 Specifying the document's character encoding), add your charset declaration early (before any ASCII art ;) to avoid a potential [encoding-related security issue](http://code.google.com/p/doctype/wiki/ArticleUtf7) in IE. It should come in the first [1024 bytes](http://www.whatwg.org/specs/web-apps/current-work/multipage/semantics.html#charset).
    > 
    > The charset should also come before the `<title>` tag, due to [potential XSS vectors](http://code.google.com/p/doctype-mirror/wiki/ArticleUtf7).

* Removed `type="text/javascript"` from `<script>` elements
* Removed `type="text/css"` from `<style>` and `<link rel=stylesheet>` elements
* Removed unneeded explicit references to `/favicon.ico` (http://mathiasbynens.be/notes/rel-shortcut-icon)

**View diff here: https://github.com/rubys/feedvalidator/pull/9/files?w=1**