### PR TITLE
itunes: add epub to supported formats

### DIFF
--- a/src/feedvalidator/itunes.py
+++ b/src/feedvalidator/itunes.py
@@ -64,7 +64,7 @@ class itunes_channel(itunes):
     return rfc2396_full(), noduplicates()
 
 class itunes_item(itunes):
-  supported_formats = ['m4a', 'mp3', 'mov', 'mp4', 'm4v', 'pdf']
+  supported_formats = ['m4a', 'mp3', 'mov', 'mp4', 'm4v', 'pdf', 'epub']
 
   def validate(self):
     pass


### PR DESCRIPTION
epub is missing in the list of supported formats, see http://www.apple.com/itunes/podcasts/specs.html#submitandfeeback