### PR TITLE
allow https URLs

### DIFF
--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -917,7 +917,7 @@ class longitude(text):
       self.log(InvalidLongitude({"parent":self.parent.name, "element":self.name, "value":self.value}))
 
 class httpURL(text):
-  http_re = re.compile("http://" + addr_spec.domain_re + '(?::\d+)?' + '(/|$)', re.IGNORECASE)
+  http_re = re.compile("(http|https)://" + addr_spec.domain_re + '(?::\d+)?' + '(/|$)', re.IGNORECASE)
   def validate(self):
     if not self.http_re.match(self.value):
       self.log(InvalidURLAttribute({"parent":self.parent.name, "element":self.name, "value":self.value}))

--- a/testcases/ext/itunes/image_absolute_https_url.xml
+++ b/testcases/ext/itunes/image_absolute_https_url.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Author:       Sam Ruby <rubys@intertwingly.net>
+-->
+
+<!--
+  Description:  Full URL specified at itunes:image href
+  Expect:       !InvalidLink{element:itunes:image}
+-->
+
+<rss xmlns:itunes="http://www.itunes.com/dtds/podcast-1.0.dtd" version="2.0">
+  <channel>
+    <title>All About Everything</title>
+    <link> http://www.itunes.com/podcasts/everything/index.html</link>
+    <description>All About Everything is a show about everything. Each week we dive into every subject known to man and talk about everything as much as we can.</description>
+
+    <item>
+      <title>Shake Shake Shake Your Spices</title>
+      <description>This week we talk about salt and pepper shakers, comparing and contrasting pour rates, construction materials, and overall aesthetics.</description>
+      <enclosure url="http://www.itunes.com/podcasts/everything/AllAboutEverythingEpisode3.mp3" length="8727310" type="x-audio/mp3" />
+      <itunes:image href="https://www.itunes.com/podcasts/everything/AllAboutEverythingEpisode3.jpg" />
+    </item>
+  </channel>
+</rss>


### PR DESCRIPTION
At the moment URLs in href tags are considered invalid. The RFC linked in the help text allows them (http://www.ietf.org/rfc/rfc3986.txt section 3.1).

Example to verify the error:

<itunes:image href="https://www.example.com/image.png"/>

The code change only makes the regex responsible for this accept http and https URLs. I also added a testcase for it. It did not break any of the other tests as far as I can see.

If you need anything else let me know.
