### PR TITLE
Adding @srcset to the acceptable attributes

### DIFF
--- a/docs-xml/warning/SecurityRiskAttr.xml
+++ b/docs-xml/warning/SecurityRiskAttr.xml
@@ -71,6 +71,7 @@ white-list approach, and only accepts the following attributes:</p>
 <code>size</code>,
 <code>span</code>,
 <code>src</code>,
+<code>srcset</code>,
 <code>start</code>,
 <code>summary</code>,
 <code>tabindex</code>,

--- a/docs/warning/SecurityRiskAttr.html
+++ b/docs/warning/SecurityRiskAttr.html
@@ -93,6 +93,7 @@ white-list approach, and only accepts the following attributes:</p>
 <code>size</code>,
 <code>span</code>,
 <code>src</code>,
+<code>srcset</code>,
 <code>start</code>,
 <code>summary</code>,
 <code>tabindex</code>,

--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -152,6 +152,7 @@ class HTMLValidator(HTMLParser):
     'prompt', 'pqg', 'radiogroup', 'readonly', 'rel', 'repeat-max',
     'repeat-min', 'replace', 'required', 'rev', 'rightspacing', 'rows',
     'rowspan', 'rules', 'scope', 'selected', 'shape', 'size', 'span', 'src',
+    'srcset', 
     'start', 'step', 'summary', 'suppress', 'tabindex', 'target', 'template',
     'title', 'toppadding', 'type', 'unselectable', 'usemap', 'urn', 'valign',
     'value', 'variable', 'volume', 'vspace', 'vrml', 'width', 'wrap',


### PR DESCRIPTION
If @src is an acceptable attribute for image elements in HTML content
in feeds, then the new @srcset attribute should be too.