### PR TITLE
Allow newer tlds

### DIFF
--- a/runtest.py
+++ b/runtest.py
@@ -5,6 +5,7 @@ modules = [
     'testXmlEncodingDecode',
     'testMediaTypes',
     'testHowtoNs',
+    'testValidators',
     'validtest',
     'mkmsgs',
 ]

--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -393,24 +393,7 @@ class noduplicates(validatorBase):
 # valid e-mail addr-spec
 #
 class addr_spec(text):
-  domains = """
-    AC AD AE AERO AF AG AI AL AM AN AO AQ AR ARPA AS ASIA AT AU AW AX AZ BA BB
-    BD BE BF BG BH BI BIZ BJ BM BN BO BR BS BT BV BW BY BZ CA CAT CC CD CF CG
-    CH CI CK CL CM CN CO COM COOP CR CU CV CX CY CZ DE DJ DK DM DO DZ EC EDU
-    EE EG ER ES ET EU FI FJ FK FM FO FR GA GB GD GE GF GG GH GI GL GM GN GOV
-    GP GQ GR GS GT GU GW GY HK HM HN HR HT HU ID IE IL IM IN INFO INT IO IQ IR
-    IS IT JE JM JO JOBS JP KE KG KH KI KM KN KP KR KW KY KZ LA LB LC LI LK LR
-    LS LT LU LV LY MA MC MD ME MG MH MIL MK ML MM MN MO MOBI MP MQ MR MS MT MU
-    MUSEUM MV MW MX MY MZ NA NAME NC NE NET NF NG NI NL NO NP NR NU NZ OM ORG
-    PA PE PF PG PH PK PL PM PN PR PRO PS PT PW PY QA RE RO RS RU RW SA SB SC
-    SD SE SG SH SI SJ SK SL SM SN SO SR ST SU SV SY SZ TC TD TEL TF TG TH TJ
-    TK TL TM TN TO TP TR TRAVEL TT TV TW TZ UA UG UK UM US UY UZ VA VC VE VG
-    VI VN VU WF WS XN--0ZWM56D XN--11B5BS3A9AJ6G XN--80AKHBYKNJ4F
-    XN--9T4B11YI5A XN--DEBA0AD XN--G6W251D XN--HGBK6AJ7F53BBA
-    XN--HLCJ6AYA9ESC7A XN--JXALPDLP XN--KGBECHTV XN--ZCKZAH YE YT YU ZA ZM ZW
-  """ # http://data.iana.org/TLD/tlds-alpha-by-domain.txt
-
-  domain_re = '''(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([A-Z0-9\-]+\.)+))(%s|[0-9]{1,3})''' % '|'.join(domains.strip().split())
+  domain_re = '''(([0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.)|(([A-Z0-9\-]+\.)+))([A-Z0-9][-A-Z0-9]*)'''
   email_re = re.compile("([A-Z0-9_\-\+\.\']+)@" + domain_re + "$", re.I)
   simple_email_re = re.compile('^[\w._%+-]+@[A-Za-z][\w.-]+$')
   message = InvalidAddrSpec

--- a/src/tests/testValidators.py
+++ b/src/tests/testValidators.py
@@ -1,0 +1,32 @@
+#!/usr/bin/python
+
+__author__ = "Joseph Walton <http://www.kafsemo.org/>"
+__copyright__ = "Copyright (c) 2011 Joseph Walton"
+
+import os, sys
+
+curdir = os.path.abspath(os.path.dirname(sys.argv[0]))
+srcdir = os.path.split(curdir)[0]
+if srcdir not in sys.path:
+  sys.path.insert(0, srcdir)
+basedir = os.path.split(srcdir)[0]
+
+import unittest
+
+from feedvalidator import validators
+
+import re
+
+class ValidatorsTest(unittest.TestCase):
+  def testExpectedTldIsAValidDomain(self):
+    print(validators.addr_spec.domain_re)
+    self.assertTrue(re.compile(validators.addr_spec.domain_re, re.I).match('feedvalidator.org'))
+
+  def testNewerTldIsAValidDomain(self):
+    self.assertTrue(re.compile(validators.addr_spec.domain_re, re.I).match('example.aaa'))
+
+def buildTestSuite():
+  return unittest.TestLoader().loadTestsFromTestCase(ValidatorsTest)
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
There are now over a thousand registered TLDs, and this will increase.
Simply check them for syntax, rather than whitelisting.
