### PR TITLE
[base.py] Fix ImportError when OS language env var value is not valid

### DIFF
--- a/src/feedvalidator/formatter/base.py
+++ b/src/feedvalidator/formatter/base.py
@@ -4,12 +4,17 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 """Base class for output classes"""
 
+from feedvalidator.logging import Info, Warning, Error
 from UserList import UserList
 import os
-LANGUAGE = os.environ.get('LANGUAGE', 'en_US:en').split(':')[-1]
-lang = __import__('feedvalidator.i18n.%s' % LANGUAGE, globals(), locals(), LANGUAGE)
 
-from feedvalidator.logging import Info, Warning, Error
+LANGUAGE = os.environ.get('LANGUAGE', 'en_US:en').split(':')[-1]
+try:
+  lang = __import__('feedvalidator.i18n.%s' % LANGUAGE, globals(), locals(), LANGUAGE)
+except ImportError:
+  LANGUAGE = 'en'
+  lang = __import__('feedvalidator.i18n.%s' % LANGUAGE, globals(), locals(), LANGUAGE)
+
 
 class BaseFormatter(UserList):
   def __getitem__(self, i):


### PR DESCRIPTION
Set a default value for LANGUAGE when the OS one is not valid. I.e.: Ubuntu's LANGUAGE env variable is 'en_US', which causes an ImportError