### PR TITLE
Support Proxy via config.py.

### DIFF
--- a/config.py
+++ b/config.py
@@ -20,3 +20,8 @@ SRCDIR = WEBDIR + r'/src'
 # The web location prefix of the docs and CSS, relative to check.cgi
 DOCSURL='docs'
 CSSURL='css'
+
+# Enable, if you are behind a Proxy...
+#os.environ['HTTP_PROXY'] = os.environ['http_proxy'] = 'http://corporate-proxy:8005'
+#os.environ['HTTPS_PROXY'] = os.environ['https_proxy'] = 'http://corporate-proxy:8005'
+#os.environ['NO_PROXY'] = os.environ['no_proxy'] = '127.0.0.1,localhost'  # Do not use Pipes or Asterisks!


### PR DESCRIPTION
Here is a solution to this problem:

https://groups.google.com/d/msg/feedvalidator-users/5pG4BYZkNJ8/uBLfeGM-8QwJ

OK, it is nearly ten years old. But I had the same problem now and I wanted to share a simple proxy setting for Python.
