### PR TITLE
Add test and fix for https enclosure url

### DIFF
--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -901,7 +901,7 @@ class longitude(text):
       self.log(InvalidLongitude({"parent":self.parent.name, "element":self.name, "value":self.value}))
 
 class httpURL(text):
-  http_re = re.compile("http://" + addr_spec.domain_re + '(?::\d+)?' + '(/|$)', re.IGNORECASE)
+  http_re = re.compile("https?://" + addr_spec.domain_re + '(?::\d+)?' + '(/|$)', re.IGNORECASE)
   def validate(self):
     if not self.http_re.match(self.value):
       self.log(InvalidURLAttribute({"parent":self.parent.name, "element":self.name, "value":self.value}))

--- a/testcases/rss20/element-channel-item-enclosure/item_enclosure_https_url.xml
+++ b/testcases/rss20/element-channel-item-enclosure/item_enclosure_https_url.xml
@@ -1,0 +1,23 @@
+<!--
+  Author:       Sam Ruby (http://intertwingly.net/) and Mark Pilgrim (http://diveintomark.org/)
+  Copyright:    Copyright (c) 2002 Sam Ruby and Mark Pilgrim
+-->
+
+<!--
+  Description:  item enclosure valid https URL
+  Expect:       ValidURLAttribute{parent:enclosure,element:url}
+-->
+
+<rss version="2.0">
+<channel>
+<title>Invalid author</title>
+<link>http://purl.org/rss/2.0/</link>
+<description>item author must include email address</description>
+<item>
+<title>Invalid author item</title>
+<link>http://purl/org/rss/2.0/?item</link>
+<description>Foo</description>
+<enclosure url="https://example.com/" length="1" type="audio/mpeg"/>
+</item>
+</channel>
+</rss>


### PR DESCRIPTION
The RSS 2.0 specification states that the enclosure element has a url attribute which "must be an http url." Given the criticality of https encryption to the modern web, I assume that this meant http as opposed to FTP or Gopher, not http excluding https.

http://www.rssboard.org/rss-specification#ltenclosuregtSubelementOfLtitemgt

iTunes Store and other entities are starting to require that the audio served in a podcast must be served via HTTPS. https://itunespartner.apple.com/en/podcasts/faq#76672088

Assuming that this makes sense, this is a patch which causes the validator to also accept https urls.

Thanks!