### PR TITLE
Force Travis distribution to Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: trusty
 language: python
 
 python:


### PR DESCRIPTION
This fixes the Travis build - Python 2.6 is not supported on newer OS in Travis