### PR TITLE
Python3

### DIFF
--- a/check.cgi
+++ b/check.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from config import *
 
 import cgi, sys, os, urlparse, sys, re, urllib

--- a/docs-xml/build-html-docs.py
+++ b/docs-xml/build-html-docs.py
@@ -9,7 +9,7 @@
 from sys import argv, stderr, exit
 
 if len(argv) < 3:
-  print >>stderr,"Usage:",argv[0]," <template.html> <target-doc-directory> [source XML document ... ]"
+  print("Usage:",argv[0]," <template.html> <target-doc-directory> [source XML document ... ]", file=stderr)
   exit(5)
 
 template = argv[1]
@@ -98,4 +98,4 @@ for f in argv[3:]:
   if ext == '.xml':
     writeDoc(sp, os.path.join(targetDir, category, name + '.html'))
   else:
-    print >>stderr,"Ignoring",f
+    print("Ignoring",f, file=stderr)

--- a/docs-xml/mkmsgs.py
+++ b/docs-xml/mkmsgs.py
@@ -25,7 +25,7 @@ template = '''
 def missing():
   result = []
 
-  for key, value in messages.items():
+  for key, value in list(messages.items()):
     if issubclass(key,Error):
       dir = 'error'
     elif issubclass(key,Warning):
@@ -58,4 +58,4 @@ if __name__ == '__main__':
     msg = re.sub("%\(\w+\)\w?", "<code>foo</code>", msg)
     if not path.exists(xml):
       open(xml,'w').write(template.lstrip() % msg)
-      print xml
+      print(xml)

--- a/fcgi.py
+++ b/fcgi.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 # Copyright (c) 2002, 2003, 2005 Allan Saddi <allan@saddi.com>
 # All rights reserved.
 #

--- a/feedfinder.py
+++ b/feedfinder.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 """feedfinder: Find the Web feed for a Web page
 http://www.aaronsw.com/2002/feedfinder/
 

--- a/index.cgi
+++ b/index.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from config import *
 
 import cgi, cgitb, sys

--- a/runtest.py
+++ b/runtest.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 modules = [
     'testFeedvalidator',
     'testUri',

--- a/src/demo.py
+++ b/src/demo.py
@@ -7,26 +7,26 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 import feedvalidator
 import sys
 import os
-import urllib
-import urllib2
-import urlparse
+import urllib.request, urllib.parse, urllib.error
+import urllib.request, urllib.error, urllib.parse
+import urllib.parse
 
 if __name__ == '__main__':
   # arg 1 is URL to validate
   link = sys.argv[1:] and sys.argv[1] or 'http://www.intertwingly.net/blog/index.atom'
-  link = urlparse.urljoin('file:' + urllib.pathname2url(os.getcwd()) + '/', link)
+  link = urllib.parse.urljoin('file:' + urllib.request.pathname2url(os.getcwd()) + '/', link)
   try:
     link = link.decode('utf-8').encode('idna')
   except:
     pass
-  print 'Validating %s' % link
+  print('Validating %s' % link)
 
   curdir = os.path.abspath(os.path.dirname(sys.argv[0]))
-  basedir = urlparse.urljoin('file:' + curdir, ".")
+  basedir = urllib.parse.urljoin('file:' + curdir, ".")
 
   try:
     if link.startswith(basedir):
-      events = feedvalidator.validateStream(urllib.urlopen(link), firstOccurrenceOnly=1,base=link.replace(basedir,"http://www.feedvalidator.org/"))['loggedEvents']
+      events = feedvalidator.validateStream(urllib.request.urlopen(link), firstOccurrenceOnly=1,base=link.replace(basedir,"http://www.feedvalidator.org/"))['loggedEvents']
     else:
       events = feedvalidator.validateURL(link, firstOccurrenceOnly=1)['loggedEvents']
   except feedvalidator.logging.ValidationFailure as vf:
@@ -44,7 +44,7 @@ if __name__ == '__main__':
   from feedvalidator.formatter.text_plain import Formatter
   output = Formatter(events)
   if output:
-      print "\n".join(output)
+      print("\n".join(output))
       sys.exit(1)
   else:
-      print "No errors or warnings"
+      print("No errors or warnings")

--- a/src/feedvalidator/__init__.py
+++ b/src/feedvalidator/__init__.py
@@ -52,7 +52,7 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
 
   # By now, aString should be Unicode
   source = InputSource()
-  source.setByteStream(StringIO(xmlEncoding.asUTF8(aString)))
+  source.setByteStream(StringIO(aString))
 
   validator = SAXDispatcher(base, selfURIs or [base], encoding)
   validator.setFirstOccurrenceOnly(firstOccurrenceOnly)
@@ -99,7 +99,7 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
     msg=[]
     libxml2.registerErrorHandler(lambda msg,str: msg.append(str), msg)
 
-    input = libxml2.inputBuffer(StringIO(xmlEncoding.asUTF8(aString)))
+    input = libxml2.inputBuffer(StringIO(aString))
     reader = input.newTextReader(prefix)
     reader.SetParserProp(libxml2.PARSER_VALIDATE, 1)
     ret = reader.Read()
@@ -114,7 +114,7 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
     parser.parse(source)
   except SAXException:
     pass
-  except UnicodeError:
+  except UnicodeDecodeError:
     import sys
     exctype, value = sys.exc_info()[:2]
     validator.log(logging.UnicodeError({"exception":value}))
@@ -134,7 +134,7 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
           self.dispatcher.log(InvalidRDF({"message": message}))
 
       source = InputSource()
-      source.setByteStream(StringIO(xmlEncoding.asUTF8(aString)))
+      source.setByteStream(StringIO(aString))
 
       parser.reset()
       parser.setContentHandler(Handler(parser.getContentHandler()))

--- a/src/feedvalidator/__init__.py
+++ b/src/feedvalidator/__init__.py
@@ -41,7 +41,6 @@ def _validate(aString, firstOccurrenceOnly, loggedEvents, base, encoding, selfUR
   """validate RSS from string, returns validator object"""
   from xml.sax import make_parser, handler
   from .base import SAXDispatcher
-  from exceptions import UnicodeError
   from io import StringIO
 
   if re.match("^\s+<\?xml",aString) and re.search("<generator.*wordpress.*</generator>",aString):

--- a/src/feedvalidator/author.py
+++ b/src/feedvalidator/author.py
@@ -10,7 +10,7 @@ from .validators import *
 #
 class author(validatorBase):
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType')]
 
   def validate(self):
     if not "name" in self.children and not "atom_name" in self.children:

--- a/src/feedvalidator/categories.py
+++ b/src/feedvalidator/categories.py
@@ -5,7 +5,7 @@ from .logging import ConflictingCatAttr, ConflictingCatChildren
 
 class categories(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None,u'scheme'),(None,u'fixed'),(None,u'href')]
+    return [(None,'scheme'),(None,'fixed'),(None,'href')]
 
   def prevalidate(self):
     self.validate_optional_attribute((None,'fixed'), yesno)

--- a/src/feedvalidator/category.py
+++ b/src/feedvalidator/category.py
@@ -10,7 +10,7 @@ from .validators import *
 #
 class category(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None,u'term'),(None,u'scheme'),(None,u'label')]
+    return [(None,'term'),(None,'scheme'),(None,'label')]
 
   def prevalidate(self):
     self.children.append(True) # force warnings about "mixed" content

--- a/src/feedvalidator/cf.py
+++ b/src/feedvalidator/cf.py
@@ -5,11 +5,11 @@ from .validators import eater, text
 
 class sort(validatorBase):
   def getExpectedAttrNames(self):
-      return [(None,u'data-type'),(None,u'default'),(None,u'element'),(None, u'label'),(None,u'ns')]
+      return [(None,'data-type'),(None,'default'),(None,'element'),(None, 'label'),(None,'ns')]
 
 class group(validatorBase):
   def getExpectedAttrNames(self):
-      return [(None,u'element'),(None, u'label'),(None,u'ns')]
+      return [(None,'element'),(None, 'label'),(None,'ns')]
 
 class listinfo(validatorBase):
   def do_cf_sort(self):

--- a/src/feedvalidator/channel.py
+++ b/src/feedvalidator/channel.py
@@ -13,9 +13,9 @@ from .extension import *
 #
 class channel(validatorBase, rfc2396, extension_channel, itunes_channel):
   def getExpectedAttrNames(self):
-    return [(u'urn:atom-extension:indexing', u'index')]
+    return [('urn:atom-extension:indexing', 'index')]
   def prevalidate(self):
-    self.validate_optional_attribute((u'urn:atom-extension:indexing', u'index'), yesno)
+    self.validate_optional_attribute(('urn:atom-extension:indexing', 'index'), yesno)
 
   def __init__(self):
     self.link=None
@@ -263,8 +263,8 @@ class rss20Channel(channel):
 
 class rss10Channel(channel):
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about'),
-      (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'about'),
+      ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'about')]
 
   def prevalidate(self):
     if (rdfNS,"about") in self.attrs:
@@ -306,12 +306,12 @@ class blink(text):
 
 class category(nonhtml):
   def getExpectedAttrNames(self):
-    return [(None, u'domain')]
+    return [(None, 'domain')]
 
 class cloud(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None, u'domain'), (None, u'path'), (None, u'registerProcedure'),
-      (None, u'protocol'), (None, u'port')]
+    return [(None, 'domain'), (None, 'path'), (None, 'registerProcedure'),
+      (None, 'protocol'), (None, 'port')]
   def prevalidate(self):
     if (None, 'domain') not in self.attrs.getNames():
       self.log(MissingAttribute({"parent":self.parent.name, "element":self.name, "attr":"domain"}))

--- a/src/feedvalidator/content.py
+++ b/src/feedvalidator/content.py
@@ -17,7 +17,7 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
   import re
 
   def getExpectedAttrNames(self):
-      return [(None, u'type'),(None, u'src')]
+      return [(None, 'type'),(None, 'src')]
 
   def normalizeWhitespace(self):
       pass
@@ -95,7 +95,7 @@ class textConstruct(validatorBase,rfc2396,nonhtml):
 
   def characters(self, string):
     for c in string:
-      if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
+      if 0x80 <= ord(c) <= 0x9F or c == '\ufffd':
         from .validators import BadCharacters
         self.log(BadCharacters({"parent":self.parent.name, "element":self.name}))
     if (self.type=='xhtml') and string.strip() and not self.value.strip():

--- a/src/feedvalidator/entry.py
+++ b/src/feedvalidator/entry.py
@@ -13,7 +13,7 @@ from .extension import extension_entry
 #
 class entry(validatorBase, extension_entry, itunes_item):
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType')]
 
   def prevalidate(self):
     self.links=[]

--- a/src/feedvalidator/extension.py
+++ b/src/feedvalidator/extension.py
@@ -711,7 +711,7 @@ class heisen_uri(rfc3987, rfc2396_full):
 
 class feedFlare(nonhtml):
   def getExpectedAttrNames(self):
-    return [(None,u'href'),(None,u'src')]
+    return [(None,'href'),(None,'src')]
   def prevalidate(self):
     self.validate_required_attribute((None,'href'),  heisen_uri)
     self.validate_required_attribute((None,'src'),  heisen_uri)
@@ -719,13 +719,13 @@ class feedFlare(nonhtml):
 
 class feedInfo(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None,u'uri')]
+    return [(None,'uri')]
   def prevalidate(self):
     self.validate_required_attribute((None,'uri'),  rfc3987)
 
 class xmlView(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None,u'href')]
+    return [(None,'href')]
   def prevalidate(self):
     self.validate_required_attribute((None,'href'),  rfc2396_full)
 
@@ -741,7 +741,7 @@ class georss_where(validatorBase):
 
 class geo_srsName(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None, u'srsName')]
+    return [(None, 'srsName')]
 
 class gml_point(geo_srsName):
   def do_gml_pos(self):
@@ -811,7 +811,7 @@ class access_restriction(enumeration):
   valuelist =  ["allow", "deny"]
 
   def getExpectedAttrNames(self):
-    return [(None, u'relationship')]
+    return [(None, 'relationship')]
 
   def prevalidate(self):
     self.children.append(True) # force warnings about "mixed" content
@@ -877,9 +877,9 @@ class extension_rss10_item(extension_item):
     return l_permalink()
 
 class l_permalink(rdfResourceURI, MimeType):
-  lNS = u'http://purl.org/rss/1.0/modules/link/'
+  lNS = 'http://purl.org/rss/1.0/modules/link/'
   def getExpectedAttrNames(self):
-    return rdfResourceURI.getExpectedAttrNames(self) + [(self.lNS, u'type')]
+    return rdfResourceURI.getExpectedAttrNames(self) + [(self.lNS, 'type')]
   def validate(self):
     if (self.lNS, 'type') in self.attrs.getNames():
       self.value=self.attrs.getValue((self.lNS, 'type'))
@@ -887,11 +887,11 @@ class l_permalink(rdfResourceURI, MimeType):
     return rdfResourceURI.validate(self)
 
 class l_link(rdfResourceURI, MimeType):
-  lNS = u'http://purl.org/rss/1.0/modules/link/'
+  lNS = 'http://purl.org/rss/1.0/modules/link/'
   def getExpectedAttrNames(self):
     return rdfResourceURI.getExpectedAttrNames(self) + [
-      (self.lNS, u'lang'), (self.lNS, u'rel'),
-      (self.lNS, u'type'), (self.lNS, u'title')
+      (self.lNS, 'lang'), (self.lNS, 'rel'),
+      (self.lNS, 'type'), (self.lNS, 'title')
     ]
   def prevalidate(self):
     self.validate_optional_attribute((self.lNS,'lang'), iso639)
@@ -1033,7 +1033,7 @@ class extension_channel(extension_channel_item):
 
 class xhtml_meta(validatorBase):
   def getExpectedAttrNames(self):
-    return [ (None, u'name'), (None, u'content') ]
+    return [ (None, 'name'), (None, 'content') ]
   def prevalidate(self):
     self.validate_required_attribute((None,'name'), xhtmlMetaEnumeration)
     self.validate_required_attribute((None,'content'), robotsEnumeration)
@@ -1084,7 +1084,7 @@ class sy_updatePeriod(text):
 class g_complex_type(validatorBase):
   def getExpectedAttrNames(self):
     if self.getFeedType() == TYPE_RSS1:
-      return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')]
+      return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType')]
     else:
       return []
 
@@ -1203,7 +1203,7 @@ class maxten(validatorBase):
 
 class in_reply_to(canonicaluri, xmlbase):
   def getExpectedAttrNames(self):
-    return [(None, u'href'), (None, u'ref'), (None, u'source'), (None, u'type')]
+    return [(None, 'href'), (None, 'ref'), (None, 'source'), (None, 'type')]
 
   def validate(self):
     if (None, "href") in self.attrs:

--- a/src/feedvalidator/feed.py
+++ b/src/feedvalidator/feed.py
@@ -13,11 +13,11 @@ from .extension import extension_feed
 #
 class feed(validatorBase, extension_feed, itunes_channel):
   def getExpectedAttrNames(self):
-    return [(u'urn:atom-extension:indexing', u'index')]
+    return [('urn:atom-extension:indexing', 'index')]
 
   def prevalidate(self):
     self.links = []
-    self.validate_optional_attribute((u'urn:atom-extension:indexing', u'index'), yesno)
+    self.validate_optional_attribute(('urn:atom-extension:indexing', 'index'), yesno)
 
   def missingElement(self, params):
     offset = [self.line - self.dispatcher.locator.getLineNumber(),

--- a/src/feedvalidator/formatter/base.py
+++ b/src/feedvalidator/formatter/base.py
@@ -4,7 +4,7 @@ __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 """Base class for output classes"""
 
-from UserList import UserList
+from collections import UserList
 import os
 LANGUAGE = os.environ.get('LANGUAGE', 'en_US:en').split(':')[-1]
 lang = __import__('feedvalidator.i18n.%s' % LANGUAGE, globals(), locals(), LANGUAGE)

--- a/src/feedvalidator/formatter/text_html.py
+++ b/src/feedvalidator/formatter/text_html.py
@@ -91,20 +91,20 @@ class Formatter(BaseFormatter):
 
     html = escapeAndMark(codeFragment)
 
-    rc = u'<li><p>'
+    rc = '<li><p>'
     if line:
-      rc += u'''<a href="#l%s">''' % line
-      rc += u'''%s</a>, ''' % self.getLine(event)
-      rc += u'''%s: ''' % self.getColumn(event)
+      rc += '''<a href="#l%s">''' % line
+      rc += '''%s</a>, ''' % self.getLine(event)
+      rc += '''%s: ''' % self.getColumn(event)
     if 'value' in event.params:
-      rc += u'''<span class="message">%s: <code>%s</code></span>''' % (escape(self.getMessage(event)), escape(unicode(event.params['value'])))
+      rc += '''<span class="message">%s: <code>%s</code></span>''' % (escape(self.getMessage(event)), escape(str(event.params['value'])))
     else:
-      rc += u'''<span class="message">%s</span>''' % escape(self.getMessage(event))
-    rc += u'''%s ''' % self.getCount(event)
-    rc += u'''[<a title="more information about this error" href="%s.html">help</a>]</p>''' % self.getHelpURL(event)
-    rc += u'''<blockquote><pre>''' + html + '''<br />'''
+      rc += '''<span class="message">%s</span>''' % escape(self.getMessage(event))
+    rc += '''%s ''' % self.getCount(event)
+    rc += '''[<a title="more information about this error" href="%s.html">help</a>]</p>''' % self.getHelpURL(event)
+    rc += '''<blockquote><pre>''' + html + '''<br />'''
     if markerColumn:
-      rc += u'&nbsp;' * markerColumn
-      rc += u'''<span class="marker">^</span>'''
-    rc += u'</pre></blockquote></li>'
+      rc += '&nbsp;' * markerColumn
+      rc += '''<span class="marker">^</span>'''
+    rc += '</pre></blockquote></li>'
     return rc

--- a/src/feedvalidator/formatter/text_xml.py
+++ b/src/feedvalidator/formatter/text_xml.py
@@ -31,7 +31,7 @@ class Formatter(BaseFormatter):
     params['level'] = level
 
     # organize fixed elements into a known order
-    order = params.keys()
+    order = list(params.keys())
     order.sort()
     for key in ['msgcount', 'text', 'column', 'line', 'type', 'level']:
       if key in order:

--- a/src/feedvalidator/generator.py
+++ b/src/feedvalidator/generator.py
@@ -10,7 +10,7 @@ from .validators import *
 #
 class generator(nonhtml,rfc2396):
   def getExpectedAttrNames(self):
-    return [(None, u'uri'), (None, u'version')]
+    return [(None, 'uri'), (None, 'version')]
 
   def prevalidate(self):
     if (None, "url") in self.attrs:

--- a/src/feedvalidator/image.py
+++ b/src/feedvalidator/image.py
@@ -11,9 +11,9 @@ from .extension import extension_everywhere
 #
 class image(validatorBase, extension_everywhere):
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'resource'),
-            (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about'),
-            (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'resource'),
+            ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'about'),
+            ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType')]
   def validate(self):
     if self.value.strip():
       self.log(UnexpectedText({"parent":self.parent.name, "element":"image"}))

--- a/src/feedvalidator/item.py
+++ b/src/feedvalidator/item.py
@@ -159,7 +159,7 @@ class rss10Item(item, extension_rss10_item):
       self.log(MissingElement({"parent":self.name, "element":"title"}))
 
   def getExpectedAttrNames(self):
-      return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about')]
+      return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'about')]
 
   def do_rdfs_label(self):
       return text()
@@ -185,7 +185,7 @@ class items(validatorBase):
   from .root import rss11_namespace as rss11_ns
 
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType')]
 
   def do_item(self):
     if self.rss11_ns not in self.dispatcher.defaultNamespaces:
@@ -203,16 +203,16 @@ class rdfSeq(validatorBase):
 
 class rdfLi(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None,u'resource'),
-            (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'resource')]
+    return [(None,'resource'),
+            ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'resource')]
 
 class category(nonhtml):
   def getExpectedAttrNames(self):
-    return [(None, u'domain')]
+    return [(None, 'domain')]
 
 class source(nonhtml):
   def getExpectedAttrNames(self):
-    return [(None, u'url')]
+    return [(None, 'url')]
   def prevalidate(self):
     self.validate_required_attribute((None,'url'), rfc2396_full)
     return text.prevalidate(self)
@@ -220,7 +220,7 @@ class source(nonhtml):
 class enclosure(validatorBase):
   from .validators import mime_re
   def getExpectedAttrNames(self):
-    return [(None, u'url'), (None, u'length'), (None, u'type')]
+    return [(None, 'url'), (None, 'length'), (None, 'type')]
   def prevalidate(self):
     try:
       if int(self.attrs.getValue((None, 'length'))) < 0:
@@ -244,7 +244,7 @@ class enclosure(validatorBase):
       self.log(MissingAttribute({"parent":self.parent.name, "element":self.name, "attr":'type'}))
 
     self.validate_required_attribute((None,'url'), httpURL)
-    if (None,u"url") in self.attrs:
+    if (None,"url") in self.attrs:
       if hasattr(self.parent,'setEnclosure'):
         self.parent.setEnclosure(self.attrs.getValue((None, 'url')))
 
@@ -252,7 +252,7 @@ class enclosure(validatorBase):
 
 class guid(rfc2396_full, noduplicates):
   def getExpectedAttrNames(self):
-    return [(None, u'isPermaLink')]
+    return [(None, 'isPermaLink')]
 
   def validate(self):
     isPermalink = 1

--- a/src/feedvalidator/itunes.py
+++ b/src/feedvalidator/itunes.py
@@ -112,7 +112,7 @@ class subcategory(validatorBase):
     self.text = None
 
   def getExpectedAttrNames(self):
-      return [(None, u'text')]
+      return [(None, 'text')]
 
   def prevalidate(self):
     try:
@@ -133,15 +133,15 @@ class subcategory(validatorBase):
 
 class image(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None, u'href')]
+    return [(None, 'href')]
 
   def prevalidate(self):
     self.validate_required_attribute((None,'href'), httpURL)
 
 class category(subcategory):
   def __init__(self):
-    subcategory.__init__(self, valid_itunes_categories.keys(),
-        old_itunes_categories.keys())
+    subcategory.__init__(self, list(valid_itunes_categories.keys()),
+        list(old_itunes_categories.keys()))
 
   def do_itunes_category(self):
     if not self.text: return eater()

--- a/src/feedvalidator/kml.py
+++ b/src/feedvalidator/kml.py
@@ -301,7 +301,7 @@ class NetworkLink(validatorBase, FeatureType, Feature):
     return Update(),noduplicates()
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_refreshInterval(self):
     return Float(), noduplicates()
@@ -318,7 +318,7 @@ class NetworkLink(validatorBase, FeatureType, Feature):
 class Document(validatorBase, FeatureType, Container, Feature):
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_ScreenOverlay(self):
     return ScreenOverlay()
@@ -334,7 +334,7 @@ class Document(validatorBase, FeatureType, Container, Feature):
 
 class Schema(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None, u'name'), (None, u'parent')]
+    return [(None, 'name'), (None, 'parent')]
 
   def do_SimpleField(self):
     return SchemaField()
@@ -351,8 +351,8 @@ class Schema(validatorBase):
 class SchemaField(validatorBase):
   def getExpectedAttrNames(self):
     return [
-      (None, u'name'),
-      (None, u'type'),
+      (None, 'name'),
+      (None, 'type'),
     ]
 
   def validate(self):
@@ -366,7 +366,7 @@ class Placemark(validatorBase, FeatureType, Geometry):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_GeometryCollection(self):
     return GeometryCollection()
@@ -376,12 +376,12 @@ class MultiGeometry(Geometry):
   # TODO: check for either geometry or multigeometry in feature, but not both?
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
 class ScreenOverlay(validatorBase, FeatureType, OverlayType):
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_geomColor(self):
     return geomColor(),noduplicates()
@@ -404,7 +404,7 @@ class GroundOverlay(validatorBase, FeatureType, OverlayType):
       self.log(MissingElement({"parent":self.name, "element":"LatLonBox"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_altitude(self):
     return FloatWithNegative(),noduplicates()
@@ -421,10 +421,10 @@ class GroundOverlay(validatorBase, FeatureType, OverlayType):
 class overlayxy(validatorBase):
   def getExpectedAttrNames(self):
     return [
-      (None, u'x'),
-      (None, u'y'),
-      (None, u'xunits'),
-      (None, u'yunits'),
+      (None, 'x'),
+      (None, 'y'),
+      (None, 'xunits'),
+      (None, 'yunits'),
     ]
 
   def validate(self):
@@ -446,7 +446,7 @@ class Region(validatorBase):
 
 class LatLonBox(validatorBase):
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def validate(self):
     if not "north" in self.children:
@@ -508,11 +508,11 @@ class Snippet(text):
     return nonhtml(),noduplicates()
 
   def getExpectedAttrNames(self):
-    return [(None, u'maxLines')]
+    return [(None, 'maxLines')]
 
 class Folder(validatorBase, FeatureType, Container, Feature):
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_NetworkLink(self):
     return NetworkLink()
@@ -526,7 +526,7 @@ class Folder(validatorBase, FeatureType, Container, Feature):
 class LookAt(validatorBase, LookAtType):
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
 class StyleMap(validatorBase):
   def validate(self):
@@ -534,7 +534,7 @@ class StyleMap(validatorBase):
       self.log(MissingElement({"parent":self.name, "element":"Pair"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_Pair(self):
     return Pair()
@@ -544,7 +544,7 @@ class Style(validatorBase):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_LineStyle(self):
     return LineStyle(), noduplicates()
@@ -575,7 +575,7 @@ class IconStyle(validatorBase, ColorStyleType):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_heading(self):
     return angle360(),noduplicates()
@@ -631,7 +631,7 @@ class BalloonStyle(validatorBase):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_textColor(self):
     return color(),noduplicates()
@@ -650,7 +650,7 @@ class ListStyle(validatorBase):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_bgColor(self):
     return color(),noduplicates()
@@ -680,7 +680,7 @@ class LabelStyle(validatorBase, ColorStyleType):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_labelColor(self):
     return labelColor(),noduplicates()
@@ -693,7 +693,7 @@ class LineStyle(validatorBase, ColorStyleType):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_width(self):
     return Float(),noduplicates()
@@ -703,7 +703,7 @@ class PolyStyle(validatorBase, ColorStyleType):
     self.validate_optional_attribute((None,'id'), unique('id',self.parent))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_fill(self):
     return zeroone(), noduplicates()
@@ -714,7 +714,7 @@ class PolyStyle(validatorBase, ColorStyleType):
 class Link(validatorBase, LinkType):
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
 class Pair(validatorBase):
   def validate(self):
@@ -735,7 +735,7 @@ class Point(validatorBase, GeometryElements):
       self.log(MissingElement({"parent":self.name, "element":"coordinates"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_coordinates(self):
     return coordinates()
@@ -747,7 +747,7 @@ class Model(validatorBase):
       self.log(MissingElement({"parent":self.name, "element":"Link"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_altitudeMode(self):
     return altitudeMode(), noduplicates()
@@ -825,7 +825,7 @@ class Polygon(validatorBase, GeometryElements):
       self.log(MissingElement({"parent":self.name, "element":"outerBoundaryIs"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_outerBoundaryIs(self):
     return boundary(), noduplicates()
@@ -847,7 +847,7 @@ class LineString(validatorBase, GeometryElements):
       self.log(MissingElement({"parent":self.name, "element":"coordinates"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_coordinates(self):
     return coordinates(), noduplicates()
@@ -858,7 +858,7 @@ class LinearRing(validatorBase, GeometryElements):
       self.log(MissingElement({"parent":self.name, "element":"coordinates"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_coordinates(self):
     return coordinates(), noduplicates()
@@ -866,7 +866,7 @@ class LinearRing(validatorBase, GeometryElements):
 class TimeSpan(validatorBase):
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_begin(self):
     return w3cdtf(),noduplicates()
@@ -880,7 +880,7 @@ class TimeStamp(validatorBase):
       self.log(MissingElement({"parent":self.name, "element":"when"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
   def do_when(self):
     return unbounded_w3cdtf(),noduplicates()
@@ -957,7 +957,7 @@ class View(validatorBase, LookAtType):
     self.log(Deprecated({"element":self.name, "replacement":"LookAt"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
 #
 # Deprecated in 2.1
@@ -995,7 +995,7 @@ class GeometryCollection(validatorBase, Geometry):
       self.log(Deprecated({"element":self.name, "replacement":"MultiGeometry"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'id')]
+    return [(None, 'id')]
 
 class Url(validatorBase, LinkType):
   def prevalidate(self):

--- a/src/feedvalidator/link.py
+++ b/src/feedvalidator/link.py
@@ -46,13 +46,13 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
     ]
 
   def getExpectedAttrNames(self):
-    return [(None, u'type'), (None, u'title'), (None, u'rel'),
-      (None, u'href'), (None, u'length'), (None, u'hreflang'),
-      (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'type'),
-      (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'resource'),
-      (u'http://purl.org/syndication/thread/1.0', u'count'),
-      (u'http://purl.org/syndication/thread/1.0', u'when'),
-      (u'http://purl.org/syndication/thread/1.0', u'updated')]
+    return [(None, 'type'), (None, 'title'), (None, 'rel'),
+      (None, 'href'), (None, 'length'), (None, 'hreflang'),
+      ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'type'),
+      ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'resource'),
+      ('http://purl.org/syndication/thread/1.0', 'count'),
+      ('http://purl.org/syndication/thread/1.0', 'when'),
+      ('http://purl.org/syndication/thread/1.0', 'updated')]
 
   def validate(self):
     self.type = ""
@@ -112,19 +112,19 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
       if self.rel == "self" and self.parent.name in ["feed","channel"]:
 
         # detect relative self values
-        from urlparse import urlparse
+        from urllib.parse import urlparse
         from xml.dom import XML_NAMESPACE
         absolute = urlparse(self.href)[1]
         element = self
         while not absolute and element and hasattr(element,'attrs'):
           pattrs = element.attrs
-          if pattrs and (XML_NAMESPACE, u'base') in pattrs:
-            absolute=urlparse(pattrs.getValue((XML_NAMESPACE, u'base')))[1]
+          if pattrs and (XML_NAMESPACE, 'base') in pattrs:
+            absolute=urlparse(pattrs.getValue((XML_NAMESPACE, 'base')))[1]
           element = element.parent
         if not absolute:
           self.log(RelativeSelf({"value":self.href}))
 
-        from urlparse import urljoin
+        from urllib.parse import urljoin
         if urljoin(self.xmlBase,self.value) not in self.dispatcher.selfURIs:
           if urljoin(self.xmlBase,self.value).split('#')[0] != self.xmlBase.split('#')[0]:
             from .uri import Uri
@@ -146,20 +146,20 @@ class link(nonblank,xmlbase,iso639,nonhtml,nonNegativeInteger,rfc3339,nonblank):
     else:
       self.log(MissingHref({"parent":self.parent.name, "element":self.name, "attr":"href"}))
 
-    if (u'http://purl.org/syndication/thread/1.0', u'count') in self.attrs:
+    if ('http://purl.org/syndication/thread/1.0', 'count') in self.attrs:
       if self.rel != "replies":
         self.log(UnexpectedAttribute({"parent":self.parent.name, "element":self.name, "attribute":"thr:count"}))
-      self.value = self.attrs.getValue((u'http://purl.org/syndication/thread/1.0', u'count'))
+      self.value = self.attrs.getValue(('http://purl.org/syndication/thread/1.0', 'count'))
       self.name="thr:count"
       nonNegativeInteger.validate(self)
 
-    if (u'http://purl.org/syndication/thread/1.0', u'when') in self.attrs:
+    if ('http://purl.org/syndication/thread/1.0', 'when') in self.attrs:
         self.log(NoThrWhen({"parent":self.parent.name, "element":self.name, "attribute":"thr:when"}))
 
-    if (u'http://purl.org/syndication/thread/1.0', u'updated') in self.attrs:
+    if ('http://purl.org/syndication/thread/1.0', 'updated') in self.attrs:
       if self.rel != "replies":
         self.log(UnexpectedAttribute({"parent":self.parent.name, "element":self.name, "attribute":"thr:updated"}))
-      self.value = self.attrs.getValue((u'http://purl.org/syndication/thread/1.0', u'updated'))
+      self.value = self.attrs.getValue(('http://purl.org/syndication/thread/1.0', 'updated'))
       self.name="thr:updated"
       rfc3339.validate(self)
 

--- a/src/feedvalidator/media.py
+++ b/src/feedvalidator/media.py
@@ -31,14 +31,14 @@ class media_elements:
 
 class media_category(nonhtml,rfc2396_full):
   def getExpectedAttrNames(self):
-      return [(None,u'label'),(None, u'scheme')]
+      return [(None,'label'),(None, 'scheme')]
   def prevalidate(self):
     self.name = "label"
-    self.value = self.attrs.get((None,u'label'))
+    self.value = self.attrs.get((None,'label'))
     if self.value: nonhtml.validate(self)
 
     self.name = "scheme"
-    self.value = self.attrs.get((None,u'scheme'))
+    self.value = self.attrs.get((None,'scheme'))
     if self.value: rfc2396_full.validate(self)
 
     self.name = "media_category"
@@ -46,10 +46,10 @@ class media_category(nonhtml,rfc2396_full):
 
 class media_copyright(nonhtml,rfc2396_full):
   def getExpectedAttrNames(self):
-      return [(None,u'url')]
+      return [(None,'url')]
   def prevalidate(self):
     self.name = "url"
-    self.value = self.attrs.get((None,u'url'))
+    self.value = self.attrs.get((None,'url'))
     if self.value: rfc2396_full.validate(self)
 
     self.name = "media_copyright"
@@ -96,7 +96,7 @@ class media_credit(text,rfc2396_full):
   ]
 
   def getExpectedAttrNames(self):
-    return [(None, u'role'),(None,u'scheme')]
+    return [(None, 'role'),(None,'scheme')]
   def prevalidate(self):
     scheme = self.attrs.get((None, 'scheme')) or 'urn:ebu'
     role = self.attrs.get((None, 'role'))
@@ -116,7 +116,7 @@ class media_credit(text,rfc2396_full):
 
 class media_hash(text):
   def getExpectedAttrNames(self):
-    return [(None,u'algo')]
+    return [(None,'algo')]
   def prevalidate(self):
     self.algo = self.attrs.get((None, 'algo'))
     if self.algo and self.algo not in ['md5', 'sha-1']:
@@ -135,7 +135,7 @@ class media_hash(text):
 
 class media_rating(rfc2396_full):
   def getExpectedAttrNames(self):
-    return [(None, u'scheme')]
+    return [(None, 'scheme')]
   def validate(self):
     scheme = self.attrs.get((None, 'scheme')) or 'urn:simple'
     if scheme == 'urn:simple':
@@ -160,7 +160,7 @@ class media_rating(rfc2396_full):
 
 class media_restriction(text,rfc2396_full,iso3166):
   def getExpectedAttrNames(self):
-    return [(None, u'relationship'),(None,u'type')]
+    return [(None, 'relationship'),(None,'type')]
   def validate(self):
     relationship = self.attrs.get((None, 'relationship'))
     if not relationship:
@@ -184,7 +184,7 @@ class media_restriction(text,rfc2396_full,iso3166):
 
 class media_player(validatorBase,positiveInteger,rfc2396_full):
   def getExpectedAttrNames(self):
-    return [(None,u'height'),(None,u'url'),(None, u'width')]
+    return [(None,'height'),(None,'url'),(None, 'width')]
   def validate(self):
     self.value = self.attrs.get((None, 'url'))
     if self.value:
@@ -203,7 +203,7 @@ class media_player(validatorBase,positiveInteger,rfc2396_full):
 
 class media_text(nonhtml):
   def getExpectedAttrNames(self):
-    return [(None,u'end'),(None,u'lang'),(None,u'start'),(None, u'type')]
+    return [(None,'end'),(None,'lang'),(None,'start'),(None, 'type')]
   def prevalidate(self):
     self.type = self.attrs.get((None, 'type'))
     if self.type and self.type not in ['plain', 'html']:
@@ -232,7 +232,7 @@ class media_text(nonhtml):
 
 class media_title(nonhtml):
   def getExpectedAttrNames(self):
-    return [(None, u'type')]
+    return [(None, 'type')]
   def prevalidate(self):
     self.type = self.attrs.get((None, 'type'))
     if self.type and self.type not in ['plain', 'html']:
@@ -246,7 +246,7 @@ class media_title(nonhtml):
 class media_thumbnail(validatorBase,positiveInteger,rfc2396_full):
   npt_re = re.compile("^(now)|(\d+(\.\d+)?)|(\d+:\d\d:\d\d(\.\d+)?)$")
   def getExpectedAttrNames(self):
-    return [(None,u'height'),(None,u'time'),(None,u'url'),(None, u'width')]
+    return [(None,'height'),(None,'time'),(None,'url'),(None, 'width')]
   def validate(self):
     time = self.attrs.get((None, 'time'))
     if time and not media_thumbnail.npt_re.match(time):
@@ -274,23 +274,23 @@ class media_content(validatorBase, media_elements, extension_everywhere,
     positiveInteger, rfc2396_full, truefalse, nonNegativeInteger):
   def getExpectedAttrNames(self):
     return [
-        (None,u'bitrate'),
-        (None,u'channels'),
-        (None,u'duration'),
-        (None,u'expression'),
-        (None,u'fileSize'),
-        (None,u'framerate'),
-        (None,u'height'),
-        (None,u'isDefault'),
-        (None,u'lang'),
-        (None,u'medium'),
-        (None,u'samplingrate'),
-        (None,u'type'),
-        (None,u'url'),
-        (None,u'width')
+        (None,'bitrate'),
+        (None,'channels'),
+        (None,'duration'),
+        (None,'expression'),
+        (None,'fileSize'),
+        (None,'framerate'),
+        (None,'height'),
+        (None,'isDefault'),
+        (None,'lang'),
+        (None,'medium'),
+        (None,'samplingrate'),
+        (None,'type'),
+        (None,'url'),
+        (None,'width')
       ]
   def validate(self):
-    self.value = self.attrs.get((None,u'bitrate'))
+    self.value = self.attrs.get((None,'bitrate'))
     if self.value and not re.match('\d+\.?\d*', self.value):
       self.log(InvalidFloat({"parent":self.parent.name, "element":self.name,
         "attr": 'bitrate', "value":self.value}))
@@ -299,12 +299,12 @@ class media_content(validatorBase, media_elements, extension_everywhere,
     self.name = "channels"
     if self.value: nonNegativeInteger.validate(self)
 
-    self.value = self.attrs.get((None,u'duration'))
+    self.value = self.attrs.get((None,'duration'))
     if self.value and not re.match('\d+\.?\d*', self.value):
       self.log(InvalidFloat({"parent":self.parent.name, "element":self.name,
         "attr": 'duration', "value":self.value}))
 
-    self.value = self.attrs.get((None,u'expression'))
+    self.value = self.attrs.get((None,'expression'))
     if self.value and self.value not in ['sample', 'full', 'nonstop']:
       self.log(InvalidMediaExpression({"parent":self.parent.name, "element":self.name, "value": self.value}))
 
@@ -312,7 +312,7 @@ class media_content(validatorBase, media_elements, extension_everywhere,
     self.name = "fileSize"
     if self.value: positiveInteger.validate(self)
 
-    self.value = self.attrs.get((None,u'framerate'))
+    self.value = self.attrs.get((None,'framerate'))
     if self.value and not re.match('\d+\.?\d*', self.value):
       self.log(InvalidFloat({"parent":self.parent.name, "element":self.name,
         "attr": 'framerate', "value":self.value}))
@@ -327,21 +327,21 @@ class media_content(validatorBase, media_elements, extension_everywhere,
     self.value = self.attrs.get((None, 'lang'))
     if self.value: iso639_validate(self.log,self.value,'lang',self.parent)
 
-    self.value = self.attrs.get((None,u'medium'))
+    self.value = self.attrs.get((None,'medium'))
     if self.value and self.value not in ['image', 'audio', 'video', 'document', 'executable']:
       self.log(InvalidMediaMedium({"parent":self.parent.name, "element":self.name, "value": self.value}))
 
-    self.value = self.attrs.get((None,u'samplingrate'))
+    self.value = self.attrs.get((None,'samplingrate'))
     if self.value and not re.match('\d+\.?\d*', self.value):
       self.log(InvalidFloat({"parent":self.parent.name, "element":self.name,
         "attr": 'samplingrate', "value":self.value}))
 
-    self.value = self.attrs.get((None,u'type'))
+    self.value = self.attrs.get((None,'type'))
     if self.value and not mime_re.match(self.value):
       self.log(InvalidMIMEAttribute({"parent":self.parent.name, "element":self.name, "attr":'type'}))
 
     self.name = "url"
-    self.value = self.attrs.get((None,u'url'))
+    self.value = self.attrs.get((None,'url'))
     if self.value: rfc2396_full.validate(self)
 
     self.value = self.attrs.get((None, 'width'))

--- a/src/feedvalidator/opensearch.py
+++ b/src/feedvalidator/opensearch.py
@@ -124,10 +124,10 @@ class QueryRole(enumeration):
 
 class UrlEncoded(validatorBase):
   def validate(self):
-    from urllib import quote, unquote
+    from urllib.parse import quote, unquote
     import re
     for value in self.value.split():
-      if type(value) == unicode: value = value.encode('utf-8')
+      if type(value) == str: value = value.encode('utf-8')
       value = re.sub('%\w\w', lambda x: x.group(0).upper(), value)
       if value != quote(unquote(value)):
         self.log(NotURLEncoded({}))

--- a/src/feedvalidator/opml.py
+++ b/src/feedvalidator/opml.py
@@ -30,7 +30,7 @@ class opml(validatorBase, extension_everywhere):
       self.log(MissingElement({"parent":self.name, "element":"body"}))
 
   def getExpectedAttrNames(self):
-    return [(None, u'version')]
+    return [(None, 'version')]
 
   def do_head(self):
     return opmlHead()
@@ -95,19 +95,19 @@ class opmlOutline(validatorBase, extension_everywhere):
 
   def getExpectedAttrNames(self):
     return [
-      (None, u'category'),
-      (None, u'created'),
-      (None, u'description'),
-      (None, u'htmlUrl'),
-      (None, u'isBreakpoint'),
-      (None, u'isComment'),
-      (None, u'language'),
-      (None, u'text'),
-      (None, u'title'),
-      (None, u'type'),
-      (None, u'url'),
-      (None, u'version'),
-      (None, u'xmlUrl'),
+      (None, 'category'),
+      (None, 'created'),
+      (None, 'description'),
+      (None, 'htmlUrl'),
+      (None, 'isBreakpoint'),
+      (None, 'isComment'),
+      (None, 'language'),
+      (None, 'text'),
+      (None, 'title'),
+      (None, 'type'),
+      (None, 'url'),
+      (None, 'version'),
+      (None, 'xmlUrl'),
     ]
 
   def validate(self):
@@ -141,8 +141,8 @@ class opmlOutline(validatorBase, extension_everywhere):
       if self.attrs[(None,'version')] not in opmlOutline.versionList:
         self.log(InvalidOutlineVersion({"parent":self.parent.name, "element":self.name, "value":self.attrs[(None,'version')]}))
 
-    if len(self.attrs)>1 and not (None,u'type') in self.attrs.getNames():
-      for name in u'description htmlUrl language title version xmlUrl'.split():
+    if len(self.attrs)>1 and not (None,'type') in self.attrs.getNames():
+      for name in 'description htmlUrl language title version xmlUrl'.split():
         if (None, name) in self.attrs.getNames():
           self.log(MissingOutlineType({"parent":self.parent.name, "element":self.name}))
           break

--- a/src/feedvalidator/rdf.py
+++ b/src/feedvalidator/rdf.py
@@ -132,8 +132,8 @@ class rdfExtension(validatorBase):
 
   def getExpectedAttrNames(self):
     # no rss11 attributes
-    if self.literal or not self.attrs: return self.attrs.keys()
-    return [(ns,n) for ns,n in self.attrs.keys() if ns!=rss11_ns]
+    if self.literal or not self.attrs: return list(self.attrs.keys())
+    return [(ns,n) for ns,n in list(self.attrs.keys()) if ns!=rss11_ns]
 
   def validate(self):
     # rdflib 2.0.5 does not catch mixed content errors
@@ -147,7 +147,7 @@ class rdfExtension(validatorBase):
       self.log(MissingNamespace({"parent":self.name, "element":name}))
 
     # ensure all attribute namespaces are properly defined
-    for (namespace,attr) in attrs.keys():
+    for (namespace,attr) in list(attrs.keys()):
       if ':' in attr and not namespace:
         from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":self.name, "element":attr}))

--- a/src/feedvalidator/rss.py
+++ b/src/feedvalidator/rss.py
@@ -19,7 +19,7 @@ class rss(validatorBase):
     return access_restriction(), noduplicates()
 
   def getExpectedAttrNames(self):
-    return [(None, u'version')]
+    return [(None, 'version')]
 
   def prevalidate(self):
     self.setFeedType(TYPE_RSS2) # could be anything in the 0.9x family, don't really care

--- a/src/feedvalidator/service.py
+++ b/src/feedvalidator/service.py
@@ -27,7 +27,7 @@ class workspace(validatorBase, extension_everywhere):
 
 class collection(validatorBase, extension_everywhere):
   def getExpectedAttrNames(self):
-    return [(None,u'href')]
+    return [(None,'href')]
 
   def prevalidate(self):
     self.validate_required_attribute((None,'href'), rfc3987)

--- a/src/feedvalidator/sse.py
+++ b/src/feedvalidator/sse.py
@@ -5,7 +5,7 @@ import re
 
 class Sharing(validatorBase):
   def getExpectedAttrNames(self):
-    return [ (None, u'expires'), (None, u'since'), (None, u'until') ]
+    return [ (None, 'expires'), (None, 'since'), (None, 'until') ]
 
   def prevalidate(self):
     if (None,'until') in self.attrs:
@@ -30,8 +30,8 @@ class Sharing(validatorBase):
 
 class Sync(validatorBase):
   def getExpectedAttrNames(self):
-    return [ (None, u'deleted'), (None, u'noconflicts'),
-             (None, u'id'), (None, u'updates') ]
+    return [ (None, 'deleted'), (None, 'noconflicts'),
+             (None, 'id'), (None, 'updates') ]
 
   def prevalidate(self):
     self.validate_optional_attribute((None,'deleted'), truefalsestrict)
@@ -52,7 +52,7 @@ class Sync(validatorBase):
 
 class Related(validatorBase):
   def getExpectedAttrNames(self):
-    return [ (None, u'link'), (None, u'title'), (None, u'type') ]
+    return [ (None, 'link'), (None, 'title'), (None, 'type') ]
 
   def prevalidate(self):
     self.validate_required_attribute((None,'link'), rfc2396_full)
@@ -62,7 +62,7 @@ class Related(validatorBase):
 
 class History(validatorBase):
   def getExpectedAttrNames(self):
-    return [ (None, u'by'), (None, u'sequence'), (None, u'when') ]
+    return [ (None, 'by'), (None, 'sequence'), (None, 'when') ]
 
   def prevalidate(self):
     self.validate_optional_attribute((None,'by'), nonhtml)

--- a/src/feedvalidator/textInput.py
+++ b/src/feedvalidator/textInput.py
@@ -10,7 +10,7 @@ from .extension import extension_everywhere
 #
 class textInput(validatorBase, extension_everywhere):
   def getExpectedAttrNames(self):
-      return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about')]
+      return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'about')]
 
   def validate(self):
     if not "title" in self.children:

--- a/src/feedvalidator/uri.py
+++ b/src/feedvalidator/uri.py
@@ -7,8 +7,8 @@ __author__ = "Joseph Walton <http://www.kafsemo.org/>"
 __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2004, 2007 Joseph Walton"
 
-from urlparse import urljoin
-from urllib import quote, quote_plus, unquote, unquote_plus
+from urllib.parse import urljoin
+from urllib.parse import quote, quote_plus, unquote, unquote_plus
 
 from unicodedata import normalize
 from codecs import lookup
@@ -121,7 +121,7 @@ def _normAuth(auth,port):
     return _normPort(h,port)
 
 def _normPath(p):
-  l = p.split(u'/')
+  l = p.split('/')
   i = 0
   if l and l[0]:
     i = len(l)
@@ -144,7 +144,7 @@ def _normPath(p):
       i += 1
   if l == ['']:
     l = ['', '']
-  return u'/'.join([_qnu(c, PCHAR) for c in l])
+  return '/'.join([_qnu(c, PCHAR) for c in l])
 
 # From RFC 2396bis, with added end-of-string marker
 uriRe = re.compile('^(([^:/?#]+):)?(//([^/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$')
@@ -197,7 +197,7 @@ def _canonical(s):
   query = _qnu(m.group(7), PCHAR + "/?")
   fragment = _qnu(m.group(9), PCHAR + "/?")
 
-  s = u''
+  s = ''
   if scheme != None:
     s += scheme + ':'
 

--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -7,6 +7,7 @@ from .logging import *
 import re, time, datetime
 from .uri import canonicalForm, urljoin
 from rfc822 import AddressList, parsedate, parsedate_tz, mktime_tz
+from functools import reduce
 
 rdfNS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
 
@@ -73,7 +74,7 @@ class eater(validatorBase):
 
   def characters(self, string):
     for c in string:
-      if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
+      if 0x80 <= ord(c) <= 0x9F or c == '\ufffd':
         from .validators import BadCharacters
         self.log(BadCharacters({"parent":self.parent.name, "element":self.name}))
 
@@ -90,12 +91,12 @@ class eater(validatorBase):
       self.log(MissingNamespace({"parent":self.name, "element":name}))
 
     # ensure all attribute namespaces are properly defined
-    for (namespace,attr) in attrs.keys():
+    for (namespace,attr) in list(attrs.keys()):
       if ':' in attr and not namespace:
         from .logging import MissingNamespace
         self.log(MissingNamespace({"parent":self.name, "element":attr}))
       for c in attrs.get((namespace,attr)):
-        if 0x80 <= ord(c) <= 0x9F or c == u'\ufffd':
+        if 0x80 <= ord(c) <= 0x9F or c == '\ufffd':
           from .validators import BadCharacters
           self.log(BadCharacters({"parent":name, "element":attr}))
 
@@ -347,15 +348,15 @@ class text(validatorBase):
   def textOK(self): pass
   def getExpectedAttrNames(self):
     if self.getFeedType() == TYPE_RSS1:
-      return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType'),
-              (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'datatype'),
-              (u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'resource')]
+      return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType'),
+              ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'datatype'),
+              ('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'resource')]
     else:
       return []
   def startElementNS(self, name, qname, attrs):
     if self.getFeedType() == TYPE_RSS1:
       if self.value.strip() or self.children:
-        if self.attrs.get((u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'parseType')) != 'Literal':
+        if self.attrs.get(('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'parseType')) != 'Literal':
           self.log(InvalidRDF({"message":"mixed content"}))
       if name=="div" and qname=="http://www.w3.org/1999/xhtml":
         from .content import diveater
@@ -421,7 +422,7 @@ def iso639_validate(log,value,element,parent):
     lang, sublang = value.split('-', 1)
   else:
     lang = value
-  if unicode.lower(unicode(lang)) not in iso639codes.isoLang:
+  if str.lower(str(lang)) not in iso639codes.isoLang:
     log(InvalidLanguage({"parent":parent, "element":element, "value":value}))
   else:
     log(ValidLanguage({"parent":parent, "element":element}))
@@ -691,21 +692,21 @@ class rfc822(text):
 #
 # Decode html entityrefs
 #
-from htmlentitydefs import name2codepoint
+from html.entities import name2codepoint
 def decodehtml(data):
   chunks=re.split('&#?(\w+);',data)
 
   for i in range(1,len(chunks),2):
     if chunks[i].isdigit():
 #      print chunks[i]
-      chunks[i]=unichr(int(chunks[i]))
+      chunks[i]=chr(int(chunks[i]))
     elif chunks[i] in name2codepoint:
-      chunks[i]=unichr(name2codepoint[chunks[i]])
+      chunks[i]=chr(name2codepoint[chunks[i]])
     else:
       chunks[i]='&' + chunks[i] +';'
 
 #  print repr(chunks)
-  return u"".join(map(unicode,chunks))
+  return "".join(map(str,chunks))
 
 #
 # Scan HTML for relative URLs
@@ -770,7 +771,7 @@ class nonhtml(text,safeHtmlMixin):#,absUrlMixin):
     # experimental RSS-Profile support
     elif self.htmlEntity_re.search(self.value):
       for value in self.htmlEntity_re.findall(self.value):
-        from htmlentitydefs import name2codepoint
+        from html.entities import name2codepoint
         if value in name2codepoint or value == 'apos' or not value.isalpha():
           if not hasattr(self,'startline'): self.startline=self.line
           lines = self.dispatcher.rssCharData[self.startline-1:self.line]
@@ -805,7 +806,7 @@ class email(addr_spec,nonhtml):
 class email_with_name(email):
   def validate(self):
     if self.value.startswith('mailto:'):
-      from urllib import unquote
+      from urllib.parse import unquote
       self.value = unquote(self.value.split(':',1)[1])
 
     if self.value.find('@')>0:
@@ -912,8 +913,8 @@ class httpURL(text):
 
 class rdfResourceURI(rfc2396):
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'resource'),
-            (u'http://purl.org/dc/elements/1.1/', u'title')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'resource'),
+            ('http://purl.org/dc/elements/1.1/', 'title')]
   def validate(self):
     if (rdfNS, 'resource') in self.attrs.getNames():
       self.value=self.attrs.getValue((rdfNS, 'resource'))
@@ -923,7 +924,7 @@ class rdfResourceURI(rfc2396):
 
 class rdfAbout(validatorBase):
   def getExpectedAttrNames(self):
-    return [(u'http://www.w3.org/1999/02/22-rdf-syntax-ns#', u'about')]
+    return [('http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'about')]
   def startElementNS(self, name, qname, attrs):
     pass
   def validate(self):

--- a/src/feedvalidator/validators.py
+++ b/src/feedvalidator/validators.py
@@ -6,7 +6,7 @@ from .base import validatorBase
 from .logging import *
 import re, time, datetime
 from .uri import canonicalForm, urljoin
-from rfc822 import AddressList, parsedate, parsedate_tz, mktime_tz
+from email.utils import getaddresses, parsedate, parsedate_tz, mktime_tz
 from functools import reduce
 
 rdfNS = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
@@ -797,7 +797,7 @@ class email(addr_spec,nonhtml):
   def validate(self):
 
     value=self.value
-    list = AddressList(value)
+    list = getaddresses(value)
     if len(list)==1: value=list[0][1]
 
     nonhtml.validate(self)

--- a/src/feedvalidator/vendor/HTMLParser.py
+++ b/src/feedvalidator/vendor/HTMLParser.py
@@ -69,7 +69,7 @@ feedvalidator specific:
 # and CDATA (character data -- only end tags are special).
 
 
-import markupbase
+import _markupbase
 import re
 
 # Regular expressions used for parsing
@@ -125,7 +125,7 @@ class HTMLParseError(Exception):
         return result
 
 
-class HTMLParser(markupbase.ParserBase):
+class HTMLParser(_markupbase.ParserBase):
     """Find tags and other markup and call handler functions.
 
     Usage:
@@ -157,7 +157,7 @@ class HTMLParser(markupbase.ParserBase):
         self.rawdata = ''
         self.lasttag = '???'
         self.interesting = interesting_normal
-        markupbase.ParserBase.reset(self)
+        _markupbase.ParserBase.reset(self)
 
     def feed(self, data):
         """Feed data to the parser.
@@ -434,15 +434,15 @@ class HTMLParser(markupbase.ParserBase):
                     c = int(s[1:], 16)
                 else:
                     c = int(s)
-                return unichr(c)
+                return chr(c)
             else:
                 # Cannot use name2codepoint directly, because HTMLParser supports apos,
                 # which is not part of HTML 4
-                import htmlentitydefs
+                import html.entities
                 if HTMLParser.entitydefs is None:
-                    entitydefs = HTMLParser.entitydefs = {'apos':u"'"}
-                    for k, v in htmlentitydefs.name2codepoint.iteritems():
-                        entitydefs[k] = unichr(v)
+                    entitydefs = HTMLParser.entitydefs = {'apos':"'"}
+                    for k, v in html.entities.name2codepoint.items():
+                        entitydefs[k] = chr(v)
                 try:
                     return self.entitydefs[s]
                 except KeyError:

--- a/src/feedvalidator/xmlEncoding.py
+++ b/src/feedvalidator/xmlEncoding.py
@@ -18,7 +18,7 @@ class FailingCodec:
   def __init__(self, name):
     self.name = name
   def fail(self, txt, errors='strict'):
-    raise UnicodeError('No codec available for ' + self.name + ' in this installation of FeedValidator')
+    raise UnicodeDecodeError('No codec available for ' + self.name + ' in this installation of FeedValidator')
 
 # Don't die if the codec can't be found, but return
 #  a decoder that will fail on use
@@ -40,11 +40,11 @@ _decACE = getdecoder('ISO-8859-1') # An ASCII-compatible encoding
 
 # Given a character index into a string, calculate its 1-based row and column
 def _position(txt, idx):
-  row = txt.count('\n', 0, idx) + 1
-  ln = txt.rfind('\n', 0, idx) + 1
+  row = txt.count(b'\n', 0, idx) + 1
+  ln = txt.rfind(b'\n', 0, idx) + 1
   column = 0
   for c in txt[ln:idx]:
-    if c == '\t':
+    if c == b'\t':
       column = (column // 8 + 1) * 8
     else:
       column += 1
@@ -52,7 +52,7 @@ def _position(txt, idx):
   return (row, column)
 
 def _normaliseNewlines(txt):
-  return txt.replace('\r\n', '\n').replace('\r', '\n')
+  return txt.replace(r'\r\n', r'\n').replace(r'\r', r'\n')
 
 def _logEvent(loggedEvents, e, pos=None):
   if pos:
@@ -121,31 +121,31 @@ def _detect(doc_start, loggedEvents=[], fallback='UTF-8'):
 
   # With a BOM. We also check for a declaration, and make sure
   #  it doesn't contradict (for 4-byte encodings, it's required)
-  if sig == '\x00\x00\xFE\xFF':  # UTF-32 BE
+  if sig == b'\x00\x00\xFE\xFF':  # UTF-32 BE
     eo = _decodeDeclaration(doc_start[4:], _decUTF32BE, ['UTF-32', 'ISO-10646-UCS-4', 'CSUCS4', 'UCS-4'], loggedEvents)
-  elif sig == '\xFF\xFE\x00\x00':  # UTF-32 LE
+  elif sig == b'\xFF\xFE\x00\x00':  # UTF-32 LE
     eo = _decodeDeclaration(doc_start[4:], _decUTF32LE, ['UTF-32', 'ISO-10646-UCS-4', 'CSUCS4', 'UCS-4'], loggedEvents)
-  elif sig == '\x00\x00\xFF\xFE'  or sig == '\xFE\xFF\x00\x00':
+  elif sig == b'\x00\x00\xFF\xFE'  or sig == b'\xFE\xFF\x00\x00':
     raise UnicodeError('Unable to process UCS-4 with unusual octet ordering')
-  elif sig[:2] == '\xFE\xFF':  # UTF-16 BE
+  elif sig[:2] == b'\xFE\xFF':  # UTF-16 BE
     eo = _decodePostBOMDeclaration(doc_start[2:], _decUTF16BE, ['UTF-16', 'ISO-10646-UCS-2', 'CSUNICODE', 'UCS-2'], loggedEvents, fallback='UTF-16')
-  elif sig[:2] == '\xFF\xFE':  # UTF-16 LE
+  elif sig[:2] == b'\xFF\xFE':  # UTF-16 LE
     eo = _decodePostBOMDeclaration(doc_start[2:], _decUTF16LE, ['UTF-16', 'ISO-10646-UCS-2', 'CSUNICODE', 'UCS-2'], loggedEvents, fallback='UTF-16')
-  elif sig[:3] == '\xEF\xBB\xBF':
+  elif sig[:3] == b'\xEF\xBB\xBF':
     eo = _decodePostBOMDeclaration(doc_start[3:], _decACE, ['UTF-8'], loggedEvents, fallback='UTF-8')
 
   # Without a BOM; we must read the declaration
-  elif sig == '\x00\x00\x00\x3C':
+  elif sig == b'\x00\x00\x00\x3C':
     eo = _decodeDeclaration(doc_start, _decUTF32BE, ['UTF-32BE', 'UTF-32', 'ISO-10646-UCS-4', 'CSUCS4', 'UCS-4'], loggedEvents)
-  elif sig == '\x3C\x00\x00\x00':
+  elif sig == b'\x3C\x00\x00\x00':
     eo = _decodeDeclaration(doc_start, _decUTF32LE, ['UTF-32LE', 'UTF-32', 'ISO-10646-UCS-4', 'CSUCS4', 'UCS-4'], loggedEvents)
-  elif sig == '\x00\x3C\x00\x3F':
+  elif sig == b'\x00\x3C\x00\x3F':
     eo = _decodeDeclaration(doc_start, _decUTF16BE, ['UTF-16BE', 'UTF-16', 'ISO-10646-UCS-2', 'CSUNICODE', 'UCS-2'], loggedEvents)
-  elif sig == '\x3C\x00\x3F\x00':
+  elif sig == b'\x3C\x00\x3F\x00':
     eo = _decodeDeclaration(doc_start, _decUTF16LE, ['UTF-16LE', 'UTF-16', 'ISO-10646-UCS-2', 'CSUNICODE', 'UCS-2'], loggedEvents)
-  elif sig == '\x3C\x3F\x78\x6D':
+  elif sig == b'\x3C\x3F\x78\x6D':
     eo = _encodingFromDecl(_normaliseNewlines(_decACE(doc_start)[0])) or ('UTF-8', None)
-  elif sig == '\x4C\x6F\xA7\x94':
+  elif sig == b'\x4C\x6F\xA7\x94':
     eo = _decodeDeclaration(doc_start, _decEBCDIC, ['IBM037', 'CP037', 'IBM038', 'EBCDIC-INT'], loggedEvents)
 
   # There's no BOM, and no declaration. It's UTF-8, or mislabelled.
@@ -162,7 +162,7 @@ def detect(doc_start, loggedEvents=[], fallback='UTF-8'):
   else:
     return None
 
-_encRe = re.compile(r'<\?xml\s+version\s*=\s*(?:"[-a-zA-Z0-9_.:]+"|\'[-a-zA-Z0-9_.:]+\')\s+(encoding\s*=\s*(?:"([-A-Za-z0-9._]+)"|\'([-A-Za-z0-9._]+)\'))')
+_encRe = re.compile(rb'<\?xml\s+version\s*=\s*(?:"[-a-zA-Z0-9_.:]+"|\'[-a-zA-Z0-9_.:]+\')\s+(encoding\s*=\s*(?:"([-A-Za-z0-9._]+)"|\'([-A-Za-z0-9._]+)\'))')
 
 def _encodingFromDecl(x):
   m = _encRe.match(x)
@@ -182,7 +182,7 @@ def removeDeclaration(x):
   if m:
     s = m.start(1)
     e = m.end(1)
-    res = x[:s] + ' ' * (e - s) + x[e:]
+    res = x[:s] + b' ' * (e - s) + x[e:]
   else:
     res = x
   return res

--- a/src/feedvalidator/xmlEncoding.py
+++ b/src/feedvalidator/xmlEncoding.py
@@ -267,7 +267,7 @@ _encUTF8 = codecs.getencoder('UTF-8')
 def asUTF8(x):
   """Accept a Unicode string and return a UTF-8 encoded string, with
   its encoding declaration removed, suitable for parsing."""
-  x = removeDeclaration(unicode(x))
+  x = removeDeclaration(str(x))
   return _encUTF8(x)[0]
 
 
@@ -282,6 +282,6 @@ if __name__ == '__main__':
       log = []
       eo = detect(l, log)
       if eo:
-        print x,eo
+        print(x,eo)
       else:
-        print repr(log)
+        print(repr(log))

--- a/src/index.py
+++ b/src/index.py
@@ -2,9 +2,9 @@ import feedvalidator
 import sys
 
 def escapeURL(url):
-    import cgi, urllib, urlparse
-    parts = map(urllib.quote, map(urllib.unquote, urlparse.urlparse(url)))
-    return cgi.escape(urlparse.urlunparse(parts))
+    import cgi, urllib.request, urllib.parse, urllib.error, urllib.parse
+    parts = list(map(urllib.parse.quote, list(map(urllib.parse.unquote, urllib.parse.urlparse(url)))))
+    return cgi.escape(urllib.parse.urlunparse(parts))
 
 def sanitizeURL(url):
     # Allow feed: URIs, as described by draft-obasanjo-feed-URI-scheme-02
@@ -74,4 +74,4 @@ def index(req,url="",out="xml"):
 if __name__=="__main__":
     import sys
     for url in sys.argv[1:]:
-      print index(0,url=url,out="html")
+      print(index(0,url=url,out="html"))

--- a/src/missingWebPages.py
+++ b/src/missingWebPages.py
@@ -39,7 +39,7 @@ areMissing=False
 
 def isclass(x):
   import types
-  return inspect.isclass(x) or type(x) == types.ClassType
+  return inspect.isclass(x) or type(x) == type
 
 for n, o in inspect.getmembers(feedvalidator.logging, isclass):
   rc = getRootClass(o)
@@ -50,7 +50,7 @@ for n, o in inspect.getmembers(feedvalidator.logging, isclass):
   if rcname in show:
     fn = os.path.join('docs', rcname, n + '.html')
     if not(isfile(os.path.join(BASE, fn))):
-      print fn
+      print(fn)
       areMissing=True
 
 if areMissing:

--- a/src/rdflib/BNode.py
+++ b/src/rdflib/BNode.py
@@ -7,7 +7,7 @@ from rdflib.Literal import Literal
 # Create a (hopefully) unique prefix so that BNode values do not
 # collide with ones created with a different instance of this module.
 prefix = ""
-for i in xrange(0,8):
+for i in range(0,8):
     prefix += choice(ascii_letters)
 
 node_id = 0

--- a/src/rdflib/Identifier.py
+++ b/src/rdflib/Identifier.py
@@ -1,4 +1,4 @@
-class Identifier(unicode):
+class Identifier(str):
     """
     See http://www.w3.org/2002/07/rdf-identifer-terminology/
     regarding choice of terminology.

--- a/src/rdflib/Literal.py
+++ b/src/rdflib/Literal.py
@@ -15,13 +15,13 @@ class Literal(Identifier):
     """
 
     def __new__(cls, value, lang='', datatype=''):
-        value = unicode(value)
+        value = str(value)
         return Identifier.__new__(cls, value)
 
     def __init__(self, value, lang='', datatype=''):
         if normalize and value:
-            if not isinstance(value, unicode):
-                value = unicode(value)
+            if not isinstance(value, str):
+                value = str(value)
             if value != normalize("NFC", value):
                 raise Error("value must be in NFC normalized form.")
 
@@ -65,5 +65,5 @@ class Literal(Identifier):
         elif isinstance(other, Identifier):
             return 0
         else:
-            return unicode(self)==other
+            return str(self)==other
 

--- a/src/rdflib/URIRef.py
+++ b/src/rdflib/URIRef.py
@@ -15,8 +15,8 @@ class URIRef(Identifier):
 
     def __init__(self, value):
         if normalize and value:
-            if not isinstance(value, unicode):
-                value = unicode(value)
+            if not isinstance(value, str):
+                value = str(value)
             if value != normalize("NFC", value):
                 raise Error("value must be in NFC normalized form.")
 

--- a/src/rdflib/syntax/parsers/RDFXMLHandler.py
+++ b/src/rdflib/syntax/parsers/RDFXMLHandler.py
@@ -31,10 +31,10 @@
 
 """
 """
-from urlparse import urljoin, urldefrag
+from urllib.parse import urljoin, urldefrag
 
 from xml.sax.saxutils import handler, quoteattr, escape
-from urllib import quote
+from urllib.parse import quote
 
 from rdflib.URIRef import URIRef
 from rdflib.BNode import BNode
@@ -194,7 +194,8 @@ class RDFXMLHandler(handler.ContentHandler):
     def processingInstruction(self, target, data):
         pass
 
-    def add_reified(self, sid, (s, p, o)):
+    def add_reified(self, sid, xxx_todo_changeme):
+        (s, p, o) = xxx_todo_changeme
         self.store.add((sid, TYPE, STATEMENT))
         self.store.add((sid, SUBJECT, s))
         self.store.add((sid, PREDICATE, p))
@@ -237,7 +238,7 @@ class RDFXMLHandler(handler.ContentHandler):
         else:
             name = "".join(name)
         atts = {}
-        for (n, v) in attrs.items(): #attrs._attrs.iteritems(): #
+        for (n, v) in list(attrs.items()): #attrs._attrs.iteritems(): #
             if n[0] is None:
                 att = n[1]
             else:
@@ -253,7 +254,7 @@ class RDFXMLHandler(handler.ContentHandler):
 
     def document_element_start(self, name, qname, attrs):
         if name[0] and "".join(name) == RDF:
-            next = self.next
+            next = self.__next__
             next.start = self.node_element_start
             next.end = self.node_element_end
         else:
@@ -267,7 +268,7 @@ class RDFXMLHandler(handler.ContentHandler):
         name, atts = self.convert(name, qname, attrs)
         current = self.current
         absolutize = self.absolutize
-        next = self.next
+        next = self.__next__
         next.start = self.property_element_start
         next.end = self.property_element_end
 
@@ -343,7 +344,7 @@ class RDFXMLHandler(handler.ContentHandler):
         name, atts = self.convert(name, qname, attrs)
         current = self.current
         absolutize = self.absolutize
-        next = self.next
+        next = self.__next__
         object = None
         current.list = None
 
@@ -508,7 +509,7 @@ class RDFXMLHandler(handler.ContentHandler):
         else:
             current.object = "<%s" % name[1]
 
-        for (name, value) in attrs.items():
+        for (name, value) in list(attrs.items()):
             if name[0]:
                 if not name[0] in current.declared:
                     current.declared[name[0]] = self._current_context[name[0]]
@@ -525,11 +526,11 @@ class RDFXMLHandler(handler.ContentHandler):
         if name[0]:
             prefix = self._current_context[name[0]]
             if prefix:
-                end = u"</%s:%s>" % (prefix, name[1])
+                end = "</%s:%s>" % (prefix, name[1])
             else:
-                end = u"</%s>" % name[1]
+                end = "</%s>" % name[1]
         else:
-            end = u"</%s>" % name[1]
+            end = "</%s>" % name[1]
         self.parent.object += self.current.object + end
 
 

--- a/src/rdflib/syntax/xml_names.py
+++ b/src/rdflib/syntax/xml_names.py
@@ -35,7 +35,7 @@ from unicodedata import category, decomposition
 
 NAME_START_CATEGORIES = ["Ll", "Lu", "Lo", "Lt", "Nl"]
 NAME_CATEGORIES = NAME_START_CATEGORIES + ["Mc", "Me", "Mn", "Lm", "Nd"]
-ALLOWED_NAME_CHARS = [u"\u00B7", u"\u0387", u"-", u".", u"_"]
+ALLOWED_NAME_CHARS = ["\u00B7", "\u0387", "-", ".", "_"]
 
 # http://www.w3.org/TR/REC-xml-names/#NT-NCName
 #  [4] NCName ::= (Letter | '_') (NCNameChar)* /* An XML Name, minus
@@ -46,7 +46,7 @@ ALLOWED_NAME_CHARS = [u"\u00B7", u"\u0387", u"-", u".", u"_"]
 def is_ncname(name):
     first = name[0]
     if first=="_" or category(first) in NAME_START_CATEGORIES:
-        for i in xrange(1, len(name)):
+        for i in range(1, len(name)):
             c = name[i]
             if not category(c) in NAME_CATEGORIES:
                 if c in ALLOWED_NAME_CHARS:
@@ -63,9 +63,9 @@ def is_ncname(name):
 def split_uri(predicate):
     predicate = predicate
     length = len(predicate)
-    for i in xrange(0, length):
+    for i in range(0, length):
         if not category(predicate[-i-1]) in NAME_CATEGORIES:
-            for j in xrange(-1-i, length):
+            for j in range(-1-i, length):
                 if category(predicate[j]) in NAME_START_CATEGORIES:
                     ns = predicate[:j]
                     if not ns:

--- a/src/tests/testHowtoNs.py
+++ b/src/tests/testHowtoNs.py
@@ -17,7 +17,7 @@ class HowtoNsTest(unittest.TestCase):
     handle=open(filename)
     page=handle.read()
     handle.close()
-    for uri,prefix in namespaces.items():
+    for uri,prefix in list(namespaces.items()):
       if prefix=='xml': continue
       if prefix=='soap': continue
       if uri.find('ModWiki')>0: continue

--- a/src/tests/testUri.py
+++ b/src/tests/testUri.py
@@ -86,7 +86,7 @@ testsCanonical = [
 
   ['http://example.com/?'],
 
-  [u'http://example.com/%C3%87'],
+  ['http://example.com/%C3%87'],
 
 
   # Other tests
@@ -202,7 +202,7 @@ def buildTestSuite():
   for a in testsInvalid:
     i+= 1
     def tstCanFindCanonicalForm(self, a):
-      self.assertEquals(feedvalidator.uri.canonicalForm(a), None)
+      self.assertEqual(feedvalidator.uri.canonicalForm(a), None)
     func = lambda self, a=a: tstCanFindCanonicalForm(self, a)
     func.__doc__ = 'Test ' + a + ' cannot be canonicalised'
     setattr(UriTest, 'test' + str(i), func)

--- a/src/tests/testXmlEncoding.py
+++ b/src/tests/testXmlEncoding.py
@@ -28,7 +28,7 @@ class EncodingTestCase(unittest.TestCase):
     except UnicodeError as u:
       self.fail("'" + self.filename + "' should not cause an exception (" + str(u) + ")")
 
-    self.assert_(enc, 'An encoding must be returned for all valid files ('
+    self.assertTrue(enc, 'An encoding must be returned for all valid files ('
         + self.filename + ')')
     self.assertEqual(enc, self.expectedEncoding, 'Encoding for '
         + self.filename + ' should be ' + self.expectedEncoding + ', but was ' + enc)
@@ -56,7 +56,7 @@ bom32BE='\x00\x00\xFE\xFF'
 bom32LE='\xFF\xFE\x00\x00'
 
 # Some fairly typical Unicode text. It should survive XML roundtripping.
-docText=u'<x>\u201c"This\uFEFF" is\na\r\u00A3t\u20Acst\u201D</x>'
+docText='<x>\u201c"This\uFEFF" is\na\r\u00A3t\u20Acst\u201D</x>'
 
 validDecl = re.compile('[A-Za-z][-A-Za-z0-9._]*')
 
@@ -145,7 +145,7 @@ def genValidXmlTestCases():
     yield('ISO-10646-UCS-4', ['BOM', 'declaration', 'LE'],
       bom32LE + encoded('UCS-4LE', makeDecl('ISO-10646-UCS-4') + docText))
   except LookupError as e:
-    print e
+    print(e)
     someFailed = True
 
 
@@ -167,7 +167,7 @@ def genValidXmlTestCases():
     try:
       yield(enc, ['declaration'], encoded(enc, makeDecl(enc) + docText))
     except LookupError as e:
-      print e
+      print(e)
       someFailed = True
 
 
@@ -186,7 +186,7 @@ def genValidXmlTestCases():
     yield('ISO-10646-UCS-4', ['declaration', 'LE'],
       bom32LE + encoded('UCS-4LE', makeDecl('ISO-10646-UCS-4') + docText))
   except LookupError as e:
-    print e
+    print(e)
     someFailed = True
 
 
@@ -203,11 +203,11 @@ def genValidXmlTestCases():
     yield('csucs4', ['alias', 'BE'],
       encoded('csucs4', makeDecl('csucs4') + docText))
   except LookupError as e:
-    print e
+    print(e)
     someFailed = True
 
   if someFailed:
-    print "Unable to generate some tests; see README for details"
+    print("Unable to generate some tests; see README for details")
 
 def genInvalidXmlTestCases():
   # Invalid files
@@ -242,7 +242,7 @@ def genInvalidXmlTestCases():
     yield('UTF-32', ['BOM', 'BE', 'noenc'],
       bom32BE + encoded('UTF-32BE', makeDecl() + docText))
   except LookupError as e:
-    print e
+    print(e)
     someFailed = True
 
   # UTF-16, no BOM, no declaration
@@ -251,7 +251,7 @@ def genInvalidXmlTestCases():
   #  until we're doing decoding as well as detection.
 
   if someFailed:
-    print "Unable to generate some tests; see README for details"
+    print("Unable to generate some tests; see README for details")
 
 def genXmlTestCases():
   for (enc, t, x) in genValidXmlTestCases():
@@ -283,7 +283,7 @@ def buildTestSuite():
       t.bytes = x
       suite.addTest(t)
     except LookupError as e:
-      print "Skipping " + name + ": " + str(e)
+      print("Skipping " + name + ": " + str(e))
       skippedNames.append(name)
   return suite
 
@@ -291,5 +291,5 @@ if __name__ == "__main__":
   s = buildTestSuite()
   unittest.TextTestRunner().run(s)
   if skippedNames:
-    print "Tests skipped:",len(skippedNames)
-    print "Please see README for details"
+    print("Tests skipped:",len(skippedNames))
+    print("Please see README for details")

--- a/src/tests/testXmlEncoding.py
+++ b/src/tests/testXmlEncoding.py
@@ -25,7 +25,7 @@ class EncodingTestCase(unittest.TestCase):
   def testEncodingMatches(self):
     try:
       enc = xmlEncoding.detect(self.bytes)
-    except UnicodeError as u:
+    except UnicodeDecodeError as u:
       self.fail("'" + self.filename + "' should not cause an exception (" + str(u) + ")")
 
     self.assertTrue(enc, 'An encoding must be returned for all valid files ('
@@ -38,7 +38,7 @@ class EncodingTestCase(unittest.TestCase):
 
     try:
       encoding = xmlEncoding.detect(self.bytes, eventLog)
-    except UnicodeError as u:
+    except UnicodeDecodeError as u:
       self.fail("'" + self.filename + "' should not cause an exception (" + str(u) + ")")
 
     if encoding:
@@ -49,11 +49,11 @@ class EncodingTestCase(unittest.TestCase):
 
 
 
-bom8='\xEF\xBB\xBF'
-bom16BE='\xFE\xFF'
-bom16LE='\xFF\xFE'
-bom32BE='\x00\x00\xFE\xFF'
-bom32LE='\xFF\xFE\x00\x00'
+bom8=b'\xEF\xBB\xBF'
+bom16BE=b'\xFE\xFF'
+bom16LE=b'\xFF\xFE'
+bom32BE=b'\x00\x00\xFE\xFF'
+bom32LE=b'\xFF\xFE\x00\x00'
 
 # Some fairly typical Unicode text. It should survive XML roundtripping.
 docText='<x>\u201c"This\uFEFF" is\na\r\u00A3t\u20Acst\u201D</x>'
@@ -76,22 +76,22 @@ def genValidXmlTestCases():
   # Required
 
   yield('UTF-8', ['BOM', 'declaration'],
-    bom8 + makeDecl('UTF-8') + encoded('UTF-8'))
+    bom8 + makeDecl('UTF-8').encode('utf-8') + encoded('UTF-8'))
 
   yield('UTF-8', [],
     encoded('UTF-8'))
 
   yield('UTF-8', ['noenc'],
-    makeDecl() + encoded('UTF-8'))
+    makeDecl().encode('utf-8') + encoded('UTF-8'))
 
   yield('UTF-8', ['declaration'],
-    makeDecl('UTF-8') + encoded('UTF-8'))
+    makeDecl('UTF-8').encode('utf-8') + encoded('UTF-8'))
 
   yield('UTF-8', ['BOM'],
     bom8 + encoded('UTF-8'))
 
   yield('UTF-8', ['BOM', 'noenc'],
-    bom8 + makeDecl('UTF-8') + encoded('UTF-8'))
+    bom8 + makeDecl('UTF-8').encode('utf-8') + encoded('UTF-8'))
 
   yield('UTF-16', ['BOM', 'declaration', 'BE'],
     bom16BE + encoded('UTF-16BE', makeDecl('UTF-16') + docText))

--- a/src/tests/testXmlEncodingDecode.py
+++ b/src/tests/testXmlEncodingDecode.py
@@ -27,20 +27,20 @@ class TestDecode(unittest.TestCase):
 
   def testProvidedEncoding(self):
     loggedEvents=[]
-    (encoding, decoded) = xmlEncoding.decode(ctAX, 'UTF-8', '<x/>', loggedEvents)
+    (encoding, decoded) = xmlEncoding.decode(ctAX, 'UTF-8', b'<x/>', loggedEvents)
     self.assertEqual('UTF-8', encoding)
     self._assertEqualUnicode(decoded, '<x/>')
     self.assertEqual(loggedEvents, [])
 
     loggedEvents=[]
-    (encoding, decoded) = xmlEncoding.decode(ctAX, 'UTF-8', '<?xml version="1.0" encoding="utf-8"?><x/>', loggedEvents)
+    (encoding, decoded) = xmlEncoding.decode(ctAX, 'UTF-8', b'<?xml version="1.0" encoding="utf-8"?><x/>', loggedEvents)
     self.assertEqual('UTF-8', encoding)
     self._assertEqualUnicode(decoded, '<?xml version="1.0" encoding="utf-8"?><x/>')
     self.assertEqual(loggedEvents, [])
 
   def testNoDeclarationOrBOM(self):
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, None, '<x/>', loggedEvents)[-1], None)
+    self.assertEqual(xmlEncoding.decode(ctAX, None, b'<x/>', loggedEvents)[-1], None)
     self.assertEqual(len(loggedEvents), 1)
     self.assertEqual(loggedEvents[0].__class__, MissingEncoding, "Must warn if there's no clue as to encoding")
 
@@ -54,45 +54,45 @@ class TestDecode(unittest.TestCase):
 
   def testJustDeclaration(self):
     loggedEvents=[]
-    (encoding, decoded) = xmlEncoding.decode(ctAX, None, '<?xml version="1.0" encoding="utf-8"?><x/>', loggedEvents)
+    (encoding, decoded) = xmlEncoding.decode(ctAX, None, b'<?xml version="1.0" encoding="utf-8"?><x/>', loggedEvents)
     self.assertEqual(encoding, 'utf-8')
     self._assertEqualUnicode(decoded, '<?xml version="1.0" encoding="utf-8"?><x/>')
     self.assertEqual(loggedEvents, [])
 
   def testSupplyUnknownEncoding(self):
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, 'X-FAKE', '<x/>', loggedEvents)[-1], None)
+    self.assertEqual(xmlEncoding.decode(ctAX, 'X-FAKE', b'<x/>', loggedEvents)[-1], None)
     self.assertEqual(len(loggedEvents), 1)
     self.assertEqual(loggedEvents[0].__class__, UnknownEncoding, 'Must fail if an unknown encoding is used')
 
   def testDeclareUnknownEncoding(self):
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, None, '<?xml version="1.0" encoding="X-FAKE"?><x/>', loggedEvents)[-1], None)
+    self.assertEqual(xmlEncoding.decode(ctAX, None, b'<?xml version="1.0" encoding="X-FAKE"?><x/>', loggedEvents)[-1], None)
     self.assertTrue(loggedEvents)
     self.assertEqual(loggedEvents[-1].__class__, UnknownEncoding)
 
   def testWarnMismatch(self):
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, 'US-ASCII', '<?xml version="1.0" encoding="UTF-8"?><x/>', loggedEvents)[-1], '<?xml version="1.0" encoding="UTF-8"?><x/>')
+    self.assertEqual(xmlEncoding.decode(ctAX, 'US-ASCII', b'<?xml version="1.0" encoding="UTF-8"?><x/>', loggedEvents)[-1], '<?xml version="1.0" encoding="UTF-8"?><x/>')
     self.assertTrue(loggedEvents)
     self.assertEqual(loggedEvents[-1].__class__, EncodingMismatch)
 
   def testDecodeUTF8(self):
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, 'utf-8', '<x>\xc2\xa3</x>', loggedEvents)[-1], '<x>\u00a3</x>')
+    self.assertEqual(xmlEncoding.decode(ctAX, 'utf-8', b'<x>\xc2\xa3</x>', loggedEvents)[-1], '<x>\u00a3</x>')
     self.assertEqual(loggedEvents, [])
 
   def testDecodeBadUTF8(self):
     """Ensure bad UTF-8 is flagged as such, but still decoded."""
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, 'utf-8', '<x>\xa3</x>', loggedEvents)[-1], '<x>\ufffd</x>')
+    self.assertEqual(xmlEncoding.decode(ctAX, 'utf-8', b'<x>\xa3</x>', loggedEvents)[-1], '<x>\ufffd</x>')
     self.assertTrue(loggedEvents)
     self.assertEqual(loggedEvents[-1].__class__, UnicodeError)
 
   def testRemovedBOM(self):
     """Make sure the initial BOM signature is not in the decoded string."""
     loggedEvents=[]
-    self.assertEqual(xmlEncoding.decode(ctAX, 'UTF-16', '\xff\xfe\x3c\x00\x78\x00\x2f\x00\x3e\x00', loggedEvents)[-1], '<x/>')
+    self.assertEqual(xmlEncoding.decode(ctAX, 'UTF-16', b'\xff\xfe\x3c\x00\x78\x00\x2f\x00\x3e\x00', loggedEvents)[-1], '<x/>')
     self.assertEqual(loggedEvents, [])
 
 

--- a/src/tests/testXmlEncodingDecode.py
+++ b/src/tests/testXmlEncodingDecode.py
@@ -21,28 +21,28 @@ ctAX='application/xml'
 class TestDecode(unittest.TestCase):
   def _assertEqualUnicode(self, a, b):
     self.assertNotEqual(a, None, 'Decoded strings should not equal None')
-    self.assertEqual(type(a), unicode, 'Decoded strings should be Unicode (was ' + str(type(a)) + ')')
-    self.assertEqual(type(b), unicode, 'Test suite error: test strings must be Unicode')
+    self.assertEqual(type(a), str, 'Decoded strings should be Unicode (was ' + str(type(a)) + ')')
+    self.assertEqual(type(b), str, 'Test suite error: test strings must be Unicode')
     self.assertEqual(a, b)
 
   def testProvidedEncoding(self):
     loggedEvents=[]
     (encoding, decoded) = xmlEncoding.decode(ctAX, 'UTF-8', '<x/>', loggedEvents)
-    self.assertEquals('UTF-8', encoding)
-    self._assertEqualUnicode(decoded, u'<x/>')
+    self.assertEqual('UTF-8', encoding)
+    self._assertEqualUnicode(decoded, '<x/>')
     self.assertEqual(loggedEvents, [])
 
     loggedEvents=[]
     (encoding, decoded) = xmlEncoding.decode(ctAX, 'UTF-8', '<?xml version="1.0" encoding="utf-8"?><x/>', loggedEvents)
-    self.assertEquals('UTF-8', encoding)
-    self._assertEqualUnicode(decoded, u'<?xml version="1.0" encoding="utf-8"?><x/>')
-    self.assertEquals(loggedEvents, [])
+    self.assertEqual('UTF-8', encoding)
+    self._assertEqualUnicode(decoded, '<?xml version="1.0" encoding="utf-8"?><x/>')
+    self.assertEqual(loggedEvents, [])
 
   def testNoDeclarationOrBOM(self):
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, None, '<x/>', loggedEvents)[-1], None)
-    self.assertEquals(len(loggedEvents), 1)
-    self.assertEquals(loggedEvents[0].__class__, MissingEncoding, "Must warn if there's no clue as to encoding")
+    self.assertEqual(xmlEncoding.decode(ctAX, None, '<x/>', loggedEvents)[-1], None)
+    self.assertEqual(len(loggedEvents), 1)
+    self.assertEqual(loggedEvents[0].__class__, MissingEncoding, "Must warn if there's no clue as to encoding")
 
 # This document is currently detected as UTF-8, rather than None.
 #
@@ -55,45 +55,45 @@ class TestDecode(unittest.TestCase):
   def testJustDeclaration(self):
     loggedEvents=[]
     (encoding, decoded) = xmlEncoding.decode(ctAX, None, '<?xml version="1.0" encoding="utf-8"?><x/>', loggedEvents)
-    self.assertEquals(encoding, 'utf-8')
-    self._assertEqualUnicode(decoded, u'<?xml version="1.0" encoding="utf-8"?><x/>')
-    self.assertEquals(loggedEvents, [])
+    self.assertEqual(encoding, 'utf-8')
+    self._assertEqualUnicode(decoded, '<?xml version="1.0" encoding="utf-8"?><x/>')
+    self.assertEqual(loggedEvents, [])
 
   def testSupplyUnknownEncoding(self):
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, 'X-FAKE', '<x/>', loggedEvents)[-1], None)
-    self.assertEquals(len(loggedEvents), 1)
-    self.assertEquals(loggedEvents[0].__class__, UnknownEncoding, 'Must fail if an unknown encoding is used')
+    self.assertEqual(xmlEncoding.decode(ctAX, 'X-FAKE', '<x/>', loggedEvents)[-1], None)
+    self.assertEqual(len(loggedEvents), 1)
+    self.assertEqual(loggedEvents[0].__class__, UnknownEncoding, 'Must fail if an unknown encoding is used')
 
   def testDeclareUnknownEncoding(self):
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, None, '<?xml version="1.0" encoding="X-FAKE"?><x/>', loggedEvents)[-1], None)
-    self.assert_(loggedEvents)
-    self.assertEquals(loggedEvents[-1].__class__, UnknownEncoding)
+    self.assertEqual(xmlEncoding.decode(ctAX, None, '<?xml version="1.0" encoding="X-FAKE"?><x/>', loggedEvents)[-1], None)
+    self.assertTrue(loggedEvents)
+    self.assertEqual(loggedEvents[-1].__class__, UnknownEncoding)
 
   def testWarnMismatch(self):
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, 'US-ASCII', '<?xml version="1.0" encoding="UTF-8"?><x/>', loggedEvents)[-1], u'<?xml version="1.0" encoding="UTF-8"?><x/>')
-    self.assert_(loggedEvents)
-    self.assertEquals(loggedEvents[-1].__class__, EncodingMismatch)
+    self.assertEqual(xmlEncoding.decode(ctAX, 'US-ASCII', '<?xml version="1.0" encoding="UTF-8"?><x/>', loggedEvents)[-1], '<?xml version="1.0" encoding="UTF-8"?><x/>')
+    self.assertTrue(loggedEvents)
+    self.assertEqual(loggedEvents[-1].__class__, EncodingMismatch)
 
   def testDecodeUTF8(self):
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, 'utf-8', '<x>\xc2\xa3</x>', loggedEvents)[-1], u'<x>\u00a3</x>')
-    self.assertEquals(loggedEvents, [])
+    self.assertEqual(xmlEncoding.decode(ctAX, 'utf-8', '<x>\xc2\xa3</x>', loggedEvents)[-1], '<x>\u00a3</x>')
+    self.assertEqual(loggedEvents, [])
 
   def testDecodeBadUTF8(self):
     """Ensure bad UTF-8 is flagged as such, but still decoded."""
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, 'utf-8', '<x>\xa3</x>', loggedEvents)[-1], u'<x>\ufffd</x>')
-    self.assert_(loggedEvents)
-    self.assertEquals(loggedEvents[-1].__class__, UnicodeError)
+    self.assertEqual(xmlEncoding.decode(ctAX, 'utf-8', '<x>\xa3</x>', loggedEvents)[-1], '<x>\ufffd</x>')
+    self.assertTrue(loggedEvents)
+    self.assertEqual(loggedEvents[-1].__class__, UnicodeError)
 
   def testRemovedBOM(self):
     """Make sure the initial BOM signature is not in the decoded string."""
     loggedEvents=[]
-    self.assertEquals(xmlEncoding.decode(ctAX, 'UTF-16', '\xff\xfe\x3c\x00\x78\x00\x2f\x00\x3e\x00', loggedEvents)[-1], u'<x/>')
-    self.assertEquals(loggedEvents, [])
+    self.assertEqual(xmlEncoding.decode(ctAX, 'UTF-16', '\xff\xfe\x3c\x00\x78\x00\x2f\x00\x3e\x00', loggedEvents)[-1], '<x/>')
+    self.assertEqual(loggedEvents, [])
 
 
 class TestRemoveDeclaration(unittest.TestCase):

--- a/src/validtest.py
+++ b/src/validtest.py
@@ -17,7 +17,7 @@ class TestCase(unittest.TestCase):
     output = Formatter(events)
     for e in events:
       if not output.format(e):
-        raise self.failureException, 'could not contruct message for %s' % e
+        raise self.failureException('could not contruct message for %s' % e)
 
   def failUnlessContainsInstanceOf(self, theClass, params, theList, msg=None):
     """Fail if there are no instances of theClass in theList with given params"""
@@ -27,14 +27,14 @@ class TestCase(unittest.TestCase):
     for item in theList:
       if issubclass(item.__class__, theClass):
         if not params: return
-        for k, v in params.items():
+        for k, v in list(params.items()):
           if str(item.params[k]) != v:
             failure=("%s.%s value was %s, expected %s" %
                (theClass.__name__, k, item.params[k], v))
             break
         else:
           return
-    raise self.failureException, failure
+    raise self.failureException(failure)
 
   def failIfContainsInstanceOf(self, theClass, params, theList, msg=None):
     """Fail if there are instances of theClass in theList with given params"""
@@ -48,16 +48,14 @@ class TestCase(unittest.TestCase):
         continue
       if issubclass(item.__class__, theClass):
         if not params:
-          raise self.failureException, \
-             (msg or 'unexpected %s' % (theClass.__name__))
+          raise self.failureException(msg or 'unexpected %s' % (theClass.__name__))
         allmatch = 1
-        for k, v in params.items():
+        for k, v in list(params.items()):
           if item.params[k] != v:
             allmatch = 0
         if allmatch:
-          raise self.failureException, \
-             "unexpected %s.%s with a value of %s" % \
-             (theClass.__name__, k, v)
+          raise self.failureException("unexpected %s.%s with a value of %s" % \
+             (theClass.__name__, k, v))
 
 desc_re = re.compile("<!--\s*Description:\s*(.*?)\s*Expect:\s*(!?)(\w*)(?:{(.*?)})?\s*-->")
 
@@ -94,7 +92,7 @@ def getDescription(xmlfile):
       excName = excName.capitalize()
       if excName=='Valid': cond,excName = '!', 'Message'
     else:
-      raise RuntimeError, "can't parse %s" % xmlfile
+      raise RuntimeError("can't parse %s" % xmlfile)
 
   if cond == "":
     method = TestCase.failUnlessContainsInstanceOf

--- a/src/validtest.py
+++ b/src/validtest.py
@@ -77,9 +77,8 @@ def getDescription(xmlfile):
 
   """
 
-  stream = open(xmlfile)
-  xmldoc = stream.read()
-  stream.close()
+  with open(xmlfile, encoding='utf-8', errors='replace') as stream:
+      xmldoc = stream.read()
 
   search_results = desc_re.search(xmldoc)
   if search_results:

--- a/src/validtest.py
+++ b/src/validtest.py
@@ -5,7 +5,7 @@ __version__ = "$Revision$"
 __copyright__ = "Copyright (c) 2002 Sam Ruby and Mark Pilgrim"
 
 import feedvalidator
-import unittest, new, os, sys, glob, re
+import unittest, types, os, sys, glob, re
 from feedvalidator.logging import Message,SelfDoesntMatchLocation,MissingSelf
 from feedvalidator import compatibility
 from feedvalidator.formatter.application_test import Formatter
@@ -131,7 +131,7 @@ def buildTestSuite():
     xmlBase  = os.path.abspath(xmlfile).replace(basedir,"http://www.feedvalidator.org")
     testName = 'test_' + xmlBase.replace(os.path.sep, "/")
     testFunc = buildTestCase(xmlfile, xmlBase, description, method, exc, params)
-    instanceMethod = new.instancemethod(testFunc, None, TestCase)
+    instanceMethod = types.MethodType(testFunc, TestCase)
     setattr(TestCase, testName, instanceMethod)
   return unittest.TestLoader().loadTestsFromTestCase(TestCase)
 

--- a/src/ws-demo.py
+++ b/src/ws-demo.py
@@ -6,7 +6,7 @@
 WS_HOST = 'www.feedvalidator.org'
 WS_URI = '/check.cgi'
 
-import urllib, httplib
+import urllib.request, urllib.parse, urllib.error, http.client
 from xml.dom import minidom
 from sys import exit
 
@@ -17,7 +17,7 @@ rawData = open('../testcases/rss/may/image_height_recommended.xml').read()
 hdrs = {'Content-Type': 'application/xml'}
 
 # Simply POST the feed contents to the validator URL
-connection=httplib.HTTPConnection(WS_HOST, 80)
+connection=http.client.HTTPConnection(WS_HOST, 80)
 connection.request('POST', WS_URI, rawData, hdrs)
 response=connection.getresponse()
 
@@ -26,20 +26,20 @@ response=connection.getresponse()
 try:
   document=minidom.parseString(response.read())
 except:
-  print "Server error, unable to validate:",response.status,response.reason
-  print "(Unable to parse response as XML.)"
+  print("Server error, unable to validate:",response.status,response.reason)
+  print("(Unable to parse response as XML.)")
   exit(20)
 
 # If the status is OK, validation took place.
 if response.status == 200:
   errors = document.getElementsByTagName("text")
   if not errors:
-    print "The feed is valid!"
+    print("The feed is valid!")
     exit(0)
   else:
     # Errors were found
     for node in errors:
-      print "".join([child.data for child in node.childNodes])
+      print("".join([child.data for child in node.childNodes]))
     exit(5)
 
 
@@ -47,13 +47,13 @@ if response.status == 200:
 elif response.status >= 500:
   errors = document.getElementsByTagName("faultstring")
   for node in errors:
-    print "".join([child.data for child in node.childNodes])
+    print("".join([child.data for child in node.childNodes]))
   traceback = document.getElementsByTagNameNS("http://www.python.org/doc/current/lib/module-traceback.html", "traceback")
   if traceback:
-    print "".join([child.data for child in traceback[0].childNodes])
+    print("".join([child.data for child in traceback[0].childNodes]))
   exit(10)
 
 # The unexpected happened...
 else:
-  print "Unexpected server response:",response.status,response.reason
+  print("Unexpected server response:",response.status,response.reason)
   exit(20)

--- a/src/ws-demo.py
+++ b/src/ws-demo.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # This is a simple demo of validation through the web service.
 

--- a/status.cgi
+++ b/status.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 print "Content-type: text/html\r\n\r\n", 
 
 import cgi, subprocess

--- a/time.cgi
+++ b/time.cgi
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 print "Content-type: text/plain\r\n\r\n",
 
 import rfc822


### PR DESCRIPTION
This is about as far as I can get without some advice/help - `runtests.py` results in a large number of errors along the lines of:

~~~
  File "/Users/mnot/Projects/feedvalidator/src/feedvalidator/media.py", line 58, in <module>
    class media_credit(text,rfc2396_full):
TypeError: Cannot create a consistent method resolution
order (MRO) for bases text, rfc2396_full
~~~

AFAICT this is because multiple inheritance is used to specify behaviours for the various validators, but that changed in the transition to new-style objects (which are the only option in Python 3).

I suspect fixing this will require a pretty serious restructuring of how the parser classes relate to each other. It's not clear to me how much work that involves. It may be better to start from scratch -- thoughts?

For #46.